### PR TITLE
Create EngineTutorial.md with hybrid Rust/Python guide

### DIFF
--- a/EngineTutorial.md
+++ b/EngineTutorial.md
@@ -1,0 +1,2231 @@
+# Game Engine Tutorial: Building a Hybrid Rust/Python Engine
+
+## Introduction
+
+Welcome to this tutorial on building your own game engine! If you've ever been curious about what goes on under the hood of your favorite games, or if you're looking to create your own custom game worlds with more control than off-the-shelf engines offer, you're in the right place.
+
+**Purpose of This Tutorial:**
+
+The primary goal of this tutorial is to guide you, step by step, in constructing a foundational game engine. We'll be using a powerful **hybrid architecture** that combines the strengths of two popular programming languages: **Rust** and **Python**.
+
+*   **Rust for the Core:** We'll leverage Rust for its incredible performance, memory safety, and low-level control. This makes it ideal for the engine's core components, such as the rendering pipeline, physics calculations, and handling large amounts of game data (like terrain).
+*   **Python for Scripting and Logic:** We'll use Python for its ease of use, rapid development capabilities, and vast ecosystem of libraries. Python will serve as the scripting layer, allowing for flexible implementation of game logic, AI behaviors, user interfaces, and overall game orchestration.
+
+**Why a Hybrid Approach?**
+
+This hybrid model offers several compelling advantages:
+
+*   **Performance Where It Matters:** By writing the performance-critical parts in Rust, we can achieve the speed necessary for complex simulations and smooth rendering, even as our engine grows.
+*   **Flexibility and Rapid Iteration:** Python allows us to quickly prototype ideas, write game scripts, and integrate various tools without the steeper learning curve or compilation times of a pure Rust project for everything.
+*   **Learning Opportunity:** This project is a fantastic way to learn or deepen your understanding of both Rust and Python. You'll see how they can interoperate and complement each other.
+*   **Directly Addressing Past Challenges:** For those familiar with the history of this project (DMTK), this approach is specifically designed to overcome previous hurdles encountered with rendering custom geometry in pure Python environments.
+
+**What You Will Achieve:**
+
+By the end of this tutorial, you will have:
+
+1.  Set up a development environment for both Rust and Python.
+2.  Created a basic Rust application that can open an OS window.
+3.  Initialized a graphics backend using `wgpu` (a modern graphics API).
+4.  Rendered custom 2D geometry (like a colored triangle or quad) within that window using your own rendering pipeline.
+5.  Organized your Rust rendering code into a reusable module.
+6.  Set up a Python project that can communicate with your Rust core.
+7.  Successfully called Rust functions from Python and passed data between the two languages using `PyO3`.
+
+Essentially, you'll have built a **Core Engine**. While it won't be a full-featured commercial engine, it will be a solid foundation, a working skeleton that you can expand upon to explore more advanced concepts like 3D rendering, terrain generation, physics integration, and much more.
+
+This tutorial will also introduce Object-Oriented Programming (OOP) concepts and analogies where applicable, helping you understand how Rust's data structures and behavior implementations relate to classes and objects you might be familiar with from other languages.
+
+Let's get started!
+
+## Setting Up Your Environment
+
+Before we dive into coding, we need to set up our development environment. This involves installing Rust, Python, and a few helpful tools.
+
+**1. Installing Rust:**
+
+Rust is managed by `rustup`, a command-line tool for installing and managing Rust versions.
+
+*   **On Windows:**
+    *   Visit [https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install) and download `rustup-init.exe`.
+    *   Run the installer and follow the on-screen instructions. The default options are usually fine.
+    *   It will also install `cargo`, Rust's package manager and build system.
+*   **On macOS and Linux:**
+    *   Open your terminal and run the following command:
+        ```bash
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+        ```
+    *   Follow the on-screen prompts. The default installation option is recommended.
+    *   This will also install `cargo`.
+*   **Verify Installation:**
+    *   After installation, open a new terminal (or restart your current one) and type:
+        ```bash
+        rustc --version
+        cargo --version
+        ```
+    *   You should see the installed versions of the Rust compiler and Cargo.
+
+**2. Installing Python:**
+
+We'll use Python 3 (preferably 3.8 or newer).
+
+*   **On Windows:**
+    *   Visit [https://www.python.org/downloads/windows/](https://www.python.org/downloads/windows/).
+    *   Download the latest Python 3 installer.
+    *   Run the installer. **Important:** Make sure to check the box that says "Add Python to PATH" during installation.
+*   **On macOS:**
+    *   macOS usually comes with Python 2 pre-installed. It's highly recommended to install Python 3 via Homebrew:
+        ```bash
+        brew install python3
+        ```
+    *   Alternatively, download the installer from [https://www.python.org/downloads/macos/](https://www.python.org/downloads/macos/).
+*   **On Linux:**
+    *   Python 3 is often pre-installed. You can check with `python3 --version`.
+    *   If not, use your distribution's package manager:
+        *   Debian/Ubuntu: `sudo apt update && sudo apt install python3 python3-pip python3-venv`
+        *   Fedora: `sudo dnf install python3 python3-pip`
+*   **Verify Installation:**
+    *   Open a terminal and type:
+        ```bash
+        python3 --version  # or just 'python --version' on Windows if added to PATH correctly
+        pip3 --version     # or 'pip --version'
+        ```
+
+**Python Virtual Environments (Highly Recommended):**
+
+It's a best practice to use virtual environments for Python projects to manage dependencies separately for each project.
+
+*   **Create a virtual environment:**
+    Navigate to your main project directory (we'll call it `GameEng` later) in the terminal and run:
+    ```bash
+    python3 -m venv venv  # Creates a 'venv' folder
+    ```
+*   **Activate the virtual environment:**
+    *   On Windows (Git Bash or similar): `source venv/Scripts/activate`
+    *   On Windows (Command Prompt): `venv\Scripts\activate.bat`
+    *   On macOS/Linux: `source venv/bin/activate`
+    *   You should see `(venv)` prefixed to your terminal prompt.
+*   **Deactivate:** Simply type `deactivate` in the terminal.
+
+We'll create and activate our virtual environment once we set up the Python project structure later in the tutorial.
+
+**3. Code Editor / IDE:**
+
+You can use any code editor you're comfortable with. However, Visual Studio Code (VS Code) is highly recommended due to its excellent support for both Rust and Python.
+
+*   **Visual Studio Code (VS Code):**
+    *   Download from [https://code.visualstudio.com/](https://code.visualstudio.com/).
+    *   **Recommended Extensions:**
+        *   `rust-analyzer`: Provides excellent language support for Rust (autocompletion, error checking, etc.).
+        *   `Python` (by Microsoft): The official Python extension for VS Code.
+        *   `CodeLLDB`: For debugging Rust code (alternative to `ms-vscode.cpptools` on some setups).
+        *   `crates`: Helps manage Rust `Cargo.toml` dependencies.
+        *   `Even Better TOML`: For TOML file syntax highlighting (used by `Cargo.toml`).
+
+With these tools installed, you're ready to start building!
+
+## Phase 1: Rust Core - The Foundation
+
+In this phase, we'll lay the groundwork for our engine by setting up the Rust core. This part will handle the heavy lifting, starting with opening a window and rendering our first piece of custom geometry. This directly addresses the most critical challenge from previous attempts: reliably drawing what we want on the screen.
+
+**Object-Oriented Programming (OOP) Analogy:**
+Think of this Rust core as the blueprint for a specialized machine. We're building the core components (like the engine block, chassis, and display mechanism) first. Rust's `struct`s will act like blueprints for individual parts (data containers), and `impl` blocks will define how these parts operate or interact (methods). While Rust isn't strictly OOP in the same way as Java or C++, its features like structs, enums, traits, and impl blocks allow us to build well-organized, encapsulated, and maintainable code that often mirrors OOP principles.
+
+### Checkpoint 1.1: Rust Project Setup
+
+First, we need a dedicated space for our Rust code. We'll create a new Rust "library" project. A library project is meant to be used by other code (like our Python scripts later), as opposed to a binary project which is a standalone executable.
+
+1.  **Create Project Directory:**
+    Open your terminal. Navigate to where you want to create your main game engine project. Let's call the main project folder `GameEng`.
+    ```bash
+    mkdir GameEng
+    cd GameEng
+    ```
+    Inside `GameEng`, we'll create the Rust core directory:
+    ```bash
+    cargo new rust_core --lib
+    ```
+    This command does a few things:
+    *   Creates a directory named `rust_core`.
+    *   Inside `rust_core`, it generates a `Cargo.toml` file and a `src` directory containing `lib.rs`.
+    *   The `--lib` flag tells Cargo to set it up as a library.
+
+2.  **Understanding `Cargo.toml`:**
+    Open `GameEng/rust_core/Cargo.toml`. It should look something like this:
+
+    ```toml
+    [package]
+    name = "rust_core"
+    version = "0.1.0"
+    edition = "2021"
+
+    [dependencies]
+    ```
+    *   `[package]`: Contains metadata about your Rust project (called a "crate" in Rust terminology).
+        *   `name`: The name of your crate.
+        *   `version`: The current version.
+        *   `edition`: Specifies the Rust language edition to use (e.g., "2021" is a recent one). This ensures language features behave consistently.
+    *   `[dependencies]`: This is where we'll list external Rust libraries (other crates) that our project needs. It's similar to `requirements.txt` in Python or `package.json` in Node.js.
+
+    **OOP Analogy:** `Cargo.toml` is like the manifest or blueprint list for our "Rust machine." It declares the machine's name, version, and most importantly, lists all the pre-built components (dependencies) it will use from other manufacturers (crates.io, the Rust community's crate registry).
+
+3.  **Exploring `src/lib.rs`:**
+    Open `GameEng/rust_core/src/lib.rs`. This is the main file for our library crate. Initially, it might contain some example test code. Let's replace it with a simple function and a test to confirm our setup.
+
+    ```rust
+    // GameEng/rust_core/src/lib.rs
+
+    pub fn get_initial_message() -> String {
+        "Rust Core Initialized!".to_string()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*; // Imports everything from the parent module (our library)
+
+        #[test]
+        fn it_works() {
+            let result = get_initial_message();
+            assert_eq!(result, "Rust Core Initialized!");
+        }
+    }
+    ```
+    *   `pub fn get_initial_message() -> String`: This defines a public function named `get_initial_message` that takes no arguments and returns a `String`. The `pub` keyword makes it accessible from outside this module.
+    *   `"Rust Core Initialized!".to_string()`: Creates a Rust `String` object.
+    *   `#[cfg(test)] mod tests { ... }`: This defines a module named `tests` that is only compiled when running tests.
+    *   `use super::*;`: Imports all items from the parent module (our `lib.rs` content) into the scope of the `tests` module.
+    *   `#[test]`: This attribute marks the following function as a test function.
+    *   `fn it_works() { ... }`: Our test function.
+    *   `assert_eq!(result, "Rust Core Initialized!");`: This macro asserts that the two arguments are equal. If not, the test will fail.
+
+4.  **Testing the Setup:**
+    Navigate into the `rust_core` directory in your terminal:
+    ```bash
+    cd rust_core
+    ```
+    Now, run the tests:
+    ```bash
+    cargo test
+    ```
+    You should see output indicating that the test `it_works` passed. This confirms your basic Rust library is set up correctly.
+
+    Next, let's make a small executable to see our function in action. We can do this by creating an "example" file.
+
+5.  **Creating an Example Executable:**
+    Create a new directory `examples` inside `rust_core/src/`:
+    ```bash
+    # Make sure you are in GameEng/rust_core
+    mkdir src/examples
+    ```
+    Now, create a file named `init_check.rs` inside `rust_core/src/examples/`:
+
+    ```rust
+    // GameEng/rust_core/src/examples/init_check.rs
+    use rust_core::get_initial_message; // Use the function from our library
+
+    fn main() {
+        println!("{}", get_initial_message());
+    }
+    ```
+    *   `use rust_core::get_initial_message;`: This line imports our `get_initial_message` function. `rust_core` refers to our library crate by its name (defined in `Cargo.toml`).
+    *   `fn main() { ... }`: The entry point for an executable program.
+    *   `println!(...)`: A macro to print text to the console.
+
+6.  **Running the Example:**
+    From the `GameEng/rust_core` directory, run:
+    ```bash
+    cargo run --example init_check
+    ```
+    You should see the output:
+    ```
+    Rust Core Initialized!
+    ```
+    This confirms that our library function can be called from another Rust program.
+
+**Checkpoint 1.1 Summary:**
+We've successfully set up a Rust library project, understood the role of `Cargo.toml` and `lib.rs`, written a basic function, tested it, and run it via an example executable. Our Rust foundation stone is laid!
+
+**Next:** We'll make this Rust core do something more visual: open a window.
+
+### Checkpoint 1.2: Basic Window Creation (Rust)
+
+Now that we have our Rust project, let's make it do something more interactive: open an operating system window. We'll use an external crate called `winit` for this. `winit` is a popular cross-platform library for window creation and event handling.
+
+1.  **Add `winit` Dependency:**
+    Open `GameEng/rust_core/Cargo.toml`. We need to tell Cargo that our project depends on `winit`. Add the following line under the `[dependencies]` section:
+
+    ```toml
+    [package]
+    name = "rust_core"
+    version = "0.1.0"
+    edition = "2021"
+
+    [dependencies]
+    winit = "0.29" # Or the latest compatible version
+    ```
+    You can find the latest version of `winit` on [crates.io](https://crates.io/crates/winit). Using a specific version like "0.29" ensures that your build is reproducible. Cargo will download and compile `winit` (and any dependencies it has) the next time you build your project.
+
+    **OOP Analogy:** We're telling our "Rust machine" (the `rust_core` crate) that it needs a "Window Management Unit" component, and we're specifying the `winit` model, version 0.29. Cargo acts as the procurement and assembly system.
+
+2.  **Create a Window Example:**
+    Let's create a new example file to demonstrate window creation. Create `window_test.rs` in the `GameEng/rust_core/src/examples/` directory:
+
+    ```rust
+    // GameEng/rust_core/src/examples/window_test.rs
+    use winit::{
+        event::{Event, WindowEvent},
+        event_loop::{ControlFlow, EventLoop},
+        window::WindowBuilder,
+    };
+
+    fn main() {
+        // 1. Create an event loop
+        // The event loop is necessary for handling window events (like close requests, keyboard input, etc.)
+        // It runs continuously until the application is explicitly told to exit.
+        let event_loop = EventLoop::new().unwrap(); // `unwrap()` will panic if creation fails
+
+        // 2. Create a window
+        // WindowBuilder lets us configure the window before creating it.
+        let window = WindowBuilder::new()
+            .with_title("My First Rust Window!")
+            .with_inner_size(winit::dpi::LogicalSize::new(800.0, 600.0)) // width, height
+            .build(&event_loop) // Actually creates the window
+            .unwrap(); // `unwrap()` will panic if window creation fails
+
+        println!("Window created successfully. Close the window to exit.");
+
+        // 3. Run the event loop
+        // This function takes control of the current thread and runs the event loop.
+        // It will dispatch events to the closure we provide.
+        let _ = event_loop.run(move |event, elwt| {
+            // ControlFlow defines how the event loop should behave after processing an event.
+            elwt.set_control_flow(ControlFlow::Wait); // Wait for the next event, conserves power
+
+            match event {
+                // Event::WindowEvent matches events specific to a window.
+                Event::WindowEvent { event, window_id } if window_id == window.id() => {
+                    match event {
+                        // WindowEvent::CloseRequested is triggered when the user clicks the close button.
+                        WindowEvent::CloseRequested => {
+                            println!("Close button pressed, exiting now.");
+                            elwt.exit(); // Tells the event loop to stop.
+                        }
+                        // WindowEvent::RedrawRequested is triggered when the OS requests the window to be redrawn.
+                        // We're not drawing anything yet, but this is where it would go.
+                        WindowEvent::RedrawRequested => {
+                            // For now, just print a message. Later, this is where we'll call our rendering code.
+                            // println!("Redraw requested");
+                        }
+                        _ => (), // Handle other window events if needed, or ignore them
+                    }
+                }
+                // Event::AboutToWait is emitted when the event loop is about to block and wait for new events.
+                // This is a good place to request a redraw if your application needs to continuously animate.
+                Event::AboutToWait => {
+                    window.request_redraw();
+                }
+                _ => (), // Handle other event types (e.g., device events) or ignore them
+            }
+        });
+    }
+    ```
+
+    **Code Breakdown:**
+    *   `use winit::{...}`: Imports necessary items from the `winit` crate.
+    *   `EventLoop::new().unwrap()`: Creates the event loop. All GUI applications need an event loop to process user input, window events, etc.
+        *   **OOP Analogy:** The `EventLoop` can be thought of as a central dispatcher object. It listens for various signals (mouse clicks, key presses, window close requests) and routes them to the appropriate handlers.
+    *   `WindowBuilder::new()...build(&event_loop).unwrap()`: Configures and creates the window.
+        *   `.with_title(...)`: Sets the window title.
+        *   `.with_inner_size(...)`: Sets the initial dimensions of the window's content area.
+        *   `.build(&event_loop)`: Consumes the builder and creates the actual `Window` object, associating it with the event loop.
+        *   **OOP Analogy:** `WindowBuilder` is a classic example of the Builder design pattern. It's an object that helps construct another complex object (`Window`) step-by-step, offering a more readable way to set various properties before finalizing the object. The resulting `window` is an object representing the OS window.
+    *   `event_loop.run(move |event, elwt| { ... })`: Starts the event loop. This function takes a closure (an anonymous function) that will be called for each event.
+        *   `elwt.set_control_flow(ControlFlow::Wait)`: Tells the event loop to wait for new events after processing the current one. `ControlFlow::Poll` would make it run continuously, consuming more CPU.
+        *   `match event { ... }`: Rust's powerful pattern matching is used to handle different types of events.
+        *   `Event::WindowEvent { event: WindowEvent::CloseRequested, .. }`: If the close button is pressed for our window.
+        *   `elwt.exit()`: This stops the event loop and allows the `main` function (and thus the program) to terminate.
+        *   `Event::AboutToWait`: This event is fired when the event loop has processed all pending events and is about to sleep. It's a good place to call `window.request_redraw()` if you want to render continuously (e.g., for animation). For now, we're just requesting a redraw, though nothing will visually change yet.
+
+3.  **Run the Window Example:**
+    Navigate to your `GameEng/rust_core` directory in the terminal and run:
+    ```bash
+    cargo run --example window_test
+    ```
+    This command will:
+    *   Compile your `window_test.rs` example.
+    *   Download and compile the `winit` crate (this might take a moment the first time).
+    *   Run the compiled executable.
+
+    You should see a window appear with the title "My First Rust Window!" and dimensions 800x600. The console will print "Window created successfully." When you click the close button on the window, the console should print "Close button pressed, exiting now," and the program will terminate.
+
+**Checkpoint 1.2 Summary:**
+We've successfully added an external dependency (`winit`) to our Rust project and used it to create and display a basic OS window. We've also learned about the event loop, which is fundamental for any interactive application. Our "Rust machine" now has a display!
+
+**Next:** We'll initialize a graphics backend (`wgpu`) so we can start drawing inside this window.
+
+### Checkpoint 1.3: Graphics Backend Initialization (Rust)
+
+We have a window, but it's just an empty frame. To draw anything in it, we need to interface with the computer's graphics hardware (the GPU). This is where `wgpu` comes in. `wgpu` is a modern, cross-platform graphics API abstraction based on the WebGPU standard. It allows us to write graphics code that can run on Vulkan, Metal, DirectX 12, and even OpenGL/WebGL under the hood.
+
+1.  **Add `wgpu` Dependency:**
+    Open `GameEng/rust_core/Cargo.toml` and add `wgpu` to your dependencies:
+
+    ```toml
+    [package]
+    name = "rust_core"
+    version = "0.1.0"
+    edition = "2021"
+
+    [dependencies]
+    winit = "0.29"
+    wgpu = "0.19" # Or the latest compatible version. Check crates.io.
+    ```
+    `wgpu` is a larger library, so this compilation step might take a bit longer.
+
+    **OOP Analogy:** We're adding a sophisticated "Graphics Processing Unit Interface Card" (`wgpu`) to our "Rust machine." This card provides the necessary connections and protocols to talk to the actual GPU.
+
+2.  **Modify `window_test.rs` for `wgpu` Initialization:**
+    We'll update our `window_test.rs` example to initialize `wgpu`. This involves several steps:
+    *   Creating a `wgpu::Instance`.
+    *   Creating a `wgpu::Surface` that links `wgpu` to our `winit` window.
+    *   Requesting a `wgpu::Adapter` (represents a physical GPU).
+    *   Requesting a `wgpu::Device` and `wgpu::Queue` (logical interface to the GPU).
+    *   Configuring the `Surface` for rendering.
+
+    Let's modify `GameEng/rust_core/src/examples/window_test.rs`:
+
+    ```rust
+    // GameEng/rust_core/src/examples/window_test.rs
+    use winit::{
+        event::{Event, WindowEvent},
+        event_loop::{ControlFlow, EventLoop},
+        window::{Window, WindowBuilder},
+    };
+
+    // New struct to hold our wgpu state
+    struct WgpuState {
+        instance: wgpu::Instance,
+        surface: wgpu::Surface<'static>, // Surface needs a lifetime; 'static for simplicity here as window lives as long as app
+        adapter: wgpu::Adapter,
+        device: wgpu::Device,
+        queue: wgpu::Queue,
+        surface_config: wgpu::SurfaceConfiguration,
+        // window: Window, // We'll pass window by reference where needed or store Arc<Window> for more complex scenarios
+    }
+
+    impl WgpuState {
+        async fn new(window: &Window) -> Self {
+            let size = window.inner_size();
+
+            // 1. Create an Instance
+            // The instance is the entry point to wgpu.
+            // We specify which backends wgpu should try to use.
+            // `Backends::all()` means wgpu will try Vulkan, Metal, DX12, Browser WebGPU, or GLES/WebGL.
+            let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+                backends: wgpu::Backends::PRIMARY, // Or wgpu::Backends::all()
+                dx12_shader_compiler: Default::default(),
+                flags: Default::default(), // No special flags
+                gles_minor_version: Default::default(), // For GLES backend
+            });
+
+            // 2. Create a Surface
+            // The surface is a platform-specific target that we can render to (our window).
+            // Needs to be 'unsafe' because the window handle must be valid for the lifetime of the surface.
+            // We ensure this by making sure `window` outlives `surface` or use `Arc<Window>` if window is passed around.
+            // For this example, window is on stack and WgpuState is created in same scope, so it's okay.
+            let surface = instance.create_surface(window).unwrap();
+
+
+            // 3. Request an Adapter
+            // The adapter represents a physical graphics device (e.g., a specific GPU or a software renderer).
+            let adapter = instance
+                .request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::default(), // Default (usually HighPerformance)
+                    compatible_surface: Some(&surface), // We need an adapter that can draw to our surface
+                    force_fallback_adapter: false, // Don't force a software renderer if a hardware one is available
+                })
+                .await // Asynchronous operation
+                .expect("Failed to find a suitable adapter");
+
+            println!("Adapter selected: {:?}", adapter.get_info());
+
+            // 4. Request a Device and Queue
+            // The device is a logical interface to the GPU, used to create resources like buffers and textures.
+            // The queue is used to submit command buffers to the GPU for execution.
+            let (device, queue) = adapter
+                .request_device(
+                    &wgpu::DeviceDescriptor {
+                        label: Some("Main Device"),
+                        required_features: wgpu::Features::empty(), // No special features needed for now
+                        required_limits: wgpu::Limits::default(),   // Use default limits
+                        memory_hints: wgpu::MemoryHints::default(), // Use default memory hints
+                    },
+                    None, // Optional trace path for API tracing
+                )
+                .await // Asynchronous operation
+                .expect("Failed to create device and queue");
+
+            println!("Device and Queue created successfully.");
+
+            // 5. Configure the Surface
+            // The surface needs to be configured with details like the texture format and size.
+            let surface_caps = surface.get_capabilities(&adapter);
+            // Choose a supported sRGB format, preferably the first one.
+            let surface_format = surface_caps.formats.iter()
+                .copied()
+                .find(|f| f.is_srgb())
+                .unwrap_or(surface_caps.formats[0]);
+
+            let surface_config = wgpu::SurfaceConfiguration {
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT, // We'll render to this surface
+                format: surface_format,
+                width: size.width,
+                height: size.height,
+                present_mode: surface_caps.present_modes[0], // Vsync, usually Fifo. Others include Mailbox (low-latency)
+                alpha_mode: surface_caps.alpha_modes[0], // Usually Opaque
+                view_formats: vec![], // For multiview
+                desired_maximum_frame_latency: 2, // Default
+            };
+            surface.configure(&device, &surface_config);
+
+            println!("Surface configured successfully.");
+
+            Self {
+                instance,
+                surface,
+                adapter,
+                device,
+                queue,
+                surface_config,
+                // window is owned by main, passed by ref
+            }
+        }
+
+        fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
+            if new_size.width > 0 && new_size.height > 0 {
+                self.surface_config.width = new_size.width;
+                self.surface_config.height = new_size.height;
+                self.surface.configure(&self.device, &self.surface_config);
+                println!("Surface resized to: {}x{}", new_size.width, new_size.height);
+            }
+        }
+
+        // We'll add a render method here in the next checkpoint
+        fn render(&mut self) -> Result<(), wgpu::SurfaceError> {
+            // For now, just clear the screen to a color
+            let output_frame = self.surface.get_current_texture()?; // Get the texture to draw on
+            let view = output_frame.texture.create_view(&wgpu::TextureViewDescriptor::default()); // Create a view of the texture
+
+            let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Render Encoder"),
+            });
+
+            // Begin a render pass
+            // A render pass is a sequence of drawing commands that target a specific set of attachments (e.g., our surface view).
+            { // Scoped to drop _render_pass before submit
+                let _render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("Main Render Pass"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &view, // The texture view to render to
+                        resolve_target: None, // For multisampling, not used here
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color { // Clear the screen
+                                r: 0.1, // Red
+                                g: 0.2, // Green
+                                b: 0.3, // Blue
+                                a: 1.0, // Alpha (opaque)
+                            }),
+                            store: wgpu::StoreOp::Store, // Store the results
+                        },
+                    })],
+                    depth_stencil_attachment: None, // No depth/stencil buffer for now
+                    timestamp_writes: None, // No timestamps
+                    occlusion_query_set: None, // No occlusion queries
+                });
+            } // _render_pass is dropped here, ending the render pass
+
+            // Submit the command buffer to the queue for execution
+            self.queue.submit(std::iter::once(encoder.finish()));
+            output_frame.present(); // Present the frame to the screen
+
+            Ok(())
+        }
+    }
+
+    // We need an async main function now because `request_adapter` and `request_device` are async.
+    // You might need to add a dependency like `pollster` to block on async futures in main.
+    // Add `pollster = "0.3"` to your Cargo.toml [dependencies]
+    fn main() {
+        env_logger::init(); // Initialize logger, good for wgpu messages
+        let event_loop = EventLoop::new().unwrap();
+        let window = WindowBuilder::new()
+            .with_title("WGPU Initialization Test")
+            .with_inner_size(winit::dpi::LogicalSize::new(800.0, 600.0))
+            .build(&event_loop)
+            .unwrap();
+
+        // Create WgpuState
+        // Since WgpuState::new is async, we need to run it in an async executor.
+        // `pollster::block_on` is a simple way to do this for main functions.
+        let mut wgpu_state = pollster::block_on(WgpuState::new(&window));
+        println!("WGPU State initialized successfully.");
+
+        let _ = event_loop.run(move |event, elwt| {
+            elwt.set_control_flow(ControlFlow::Wait);
+
+            match event {
+                Event::WindowEvent { event, window_id } if window_id == window.id() => {
+                    match event {
+                        WindowEvent::CloseRequested => {
+                            println!("Close button pressed, exiting now.");
+                            elwt.exit();
+                        }
+                        WindowEvent::Resized(physical_size) => {
+                            println!("Window resized event received.");
+                            wgpu_state.resize(physical_size);
+                        }
+                        WindowEvent::RedrawRequested => {
+                            // This is where we'll draw.
+                            // For now, we'll just clear the screen to a color.
+                            match wgpu_state.render() {
+                                Ok(_) => {}
+                                // Reconfigure the surface if lost
+                                Err(wgpu::SurfaceError::Lost) => wgpu_state.resize(window.inner_size()),
+                                // The system is out of memory, we should probably quit
+                                Err(wgpu::SurfaceError::OutOfMemory) => elwt.exit(),
+                                // All other errors (Outdated, Timeout) should be resolved by the next frame
+                                Err(e) => eprintln!("Error during render: {:?}", e),
+                            }
+                        }
+                        _ => (),
+                    }
+                }
+                Event::AboutToWait => {
+                    window.request_redraw();
+                }
+                _ => (),
+            }
+        });
+    }
+    ```
+
+    **Key changes and explanations:**
+    *   **`pollster` Crate:** `wgpu`'s `request_adapter` and `request_device` are asynchronous functions (they return Futures). To call them from our synchronous `main` function, we use `pollster::block_on`. Add `pollster = "0.3"` to your `Cargo.toml` under `[dependencies]`.
+    *   **`env_logger` Crate:** It's good practice to initialize a logger like `env_logger` when working with `wgpu` as it can provide useful diagnostic messages. Add `env_logger = "0.10"` (or latest) to `Cargo.toml` and call `env_logger::init();` at the start of `main`.
+    *   **`WgpuState` struct:** We've encapsulated all the `wgpu`-related objects (`Instance`, `Surface`, `Adapter`, `Device`, `Queue`, `SurfaceConfiguration`) into a struct. This is good practice for organization.
+        *   **OOP Analogy:** `WgpuState` is like a dedicated "GraphicsManager" object. It holds all the essential sub-components (objects like `Device`, `Queue`, etc.) required for graphics operations and provides methods to manage them (like `new` for initialization, `resize`).
+    *   **`WgpuState::new(window: &Window)` (async fn):**
+        *   `wgpu::Instance::new(...)`: Creates the main `wgpu` entry point.
+        *   `instance.create_surface(window)`: Creates a `Surface` linked to our `winit` window. The `window` reference must be valid for the lifetime of the `Surface`. `'static` lifetime on `surface: wgpu::Surface<'static>` is a simplification; in more complex apps, you'd use `Arc<Window>` or ensure lifetimes are correctly managed.
+        *   `instance.request_adapter(...)`: Asynchronously requests a physical device (GPU).
+        *   `adapter.request_device(...)`: Asynchronously requests a logical device and command queue.
+        *   `surface.get_capabilities(&adapter)` and `surface.configure(...)`: Queries the surface for supported formats and configures it for rendering with a chosen format, size, and presentation mode.
+    *   **`WgpuState::resize(...)`:** This method is called when the window is resized. It updates the `surface_config` with the new dimensions and reconfigures the `surface`.
+    *   **`WgpuState::render(...)`:** This is a placeholder for now. It:
+        *   Gets the current texture from the swap chain (`surface.get_current_texture()`).
+        *   Creates a `TextureView` (how the texture is interpreted by the GPU).
+        *   Creates a `CommandEncoder` to record GPU commands.
+        *   Begins a `RenderPass`. The `RenderPassDescriptor` specifies what to do with color attachments. Here, we `Clear` it to a dark blue-grey color (`wgpu::Color { r: 0.1, g: 0.2, b: 0.3, a: 1.0 }`).
+        *   Submits the command buffer to the `queue`.
+        *   Presents the rendered frame (`output_frame.present()`).
+    *   **Event Loop Changes:**
+        *   `WindowEvent::Resized(physical_size)`: When the window is resized, we call `wgpu_state.resize()`.
+        *   `WindowEvent::RedrawRequested`: We now call `wgpu_state.render()`. Error handling is added for `SurfaceError` cases (like `Lost` or `OutOfMemory`).
+
+3.  **Run the Graphics Initialization Example:**
+    Make sure you've added `pollster = "0.3"` and `env_logger = "0.10"` to your `GameEng/rust_core/Cargo.toml`. Your `[dependencies]` section should now look something like this:
+    ```toml
+    [dependencies]
+    winit = "0.29"
+    wgpu = "0.19"
+    pollster = "0.3"
+    env_logger = "0.10" # Or your chosen logging crate
+    ```
+    Then, from the `GameEng/rust_core` directory, run:
+    ```bash
+    cargo run --example window_test
+    ```
+    If everything is set up correctly:
+    *   The program will compile (this might take a while for `wgpu` the first time).
+    *   A window will appear.
+    *   Instead of being empty or transparent, the window should now be filled with a solid color (the dark blue-grey we specified: R:0.1, G:0.2, B:0.3).
+    *   Your console will show log messages, including information about the selected adapter, device creation, and surface configuration.
+    *   Resizing the window should trigger the `resize` logic, and the colored background should adapt.
+    *   Closing the window will terminate the program.
+
+**Checkpoint 1.3 Summary:**
+We've successfully initialized `wgpu`! Our Rust application can now create a window, connect to the graphics hardware, and clear the window to a specific color. This is a major step towards rendering custom graphics. We've also organized our graphics state into a `WgpuState` struct, which is a good OOP-like practice.
+
+**Next:** The exciting part – drawing actual custom geometry (like a triangle) onto this colored background! This is the critical test.
+
+### Checkpoint 1.4: Render Pipeline & Custom Geometry (Rust) - CRITICAL CHECKPOINT
+
+This is the moment of truth. We'll define a simple shape (a triangle), tell the GPU how to draw it using shaders, and then issue the draw command. This directly validates our ability to render custom geometry, a key goal.
+
+We'll need to:
+1.  Define a vertex structure.
+2.  Create vertex and index buffers on the GPU.
+3.  Write simple vertex and fragment shaders in WGSL (WebGPU Shading Language).
+4.  Create a `wgpu::RenderPipeline`.
+5.  Modify the `render` method in `WgpuState` to draw our geometry.
+
+1.  **Define Vertex Structure:**
+    A vertex is a point in space, often with associated data like color or texture coordinates. We'll create a simple vertex with a 2D position and a color.
+
+    Create a new file `GameEng/rust_core/src/vertex.rs` (or you can define it directly in `window_test.rs` for simplicity at this stage, but a separate file is cleaner for future expansion).
+
+    ```rust
+    // GameEng/rust_core/src/vertex.rs
+    #[repr(C)] // Ensures struct has a C-compatible memory layout
+    #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)] // Traits for easy conversion to byte slices
+    pub struct Vertex {
+        pub position: [f32; 2], // x, y
+        pub color: [f32; 3],    // r, g, b
+    }
+
+    impl Vertex {
+        // Describes how vertex data is laid out in memory for the GPU
+        pub fn desc<'a>() -> wgpu::VertexBufferLayout<'a> {
+            wgpu::VertexBufferLayout {
+                array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress, // How many bytes from one vertex to the next
+                step_mode: wgpu::VertexStepMode::Vertex, // Advance per vertex (not per instance)
+                attributes: &[ // Define each attribute (field) of the vertex
+                    wgpu::VertexAttribute {
+                        offset: 0, // Byte offset of this attribute within the vertex
+                        shader_location: 0, // Corresponds to `layout(location = 0)` in WGSL vertex shader
+                        format: wgpu::VertexFormat::Float32x2, // [f32; 2] for position
+                    },
+                    wgpu::VertexAttribute {
+                        offset: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress, // Offset after the position
+                        shader_location: 1, // Corresponds to `layout(location = 1)` in WGSL vertex shader
+                        format: wgpu::VertexFormat::Float32x3, // [f32; 3] for color
+                    },
+                ],
+            }
+        }
+    }
+    ```
+    *   `#[repr(C)]`: Important for ensuring Rust lays out the struct in memory in a way that's predictable and compatible with how GPUs (and C APIs) expect data.
+    *   `bytemuck::Pod` and `bytemuck::Zeroable`: These traits (from the `bytemuck` crate) are helper traits that allow us to safely cast slices of our `Vertex` struct into raw byte slices (`&[u8]`), which is what `wgpu` needs for buffer creation. Add `bytemuck = { version = "1.12", features = ["derive"] }` to your `Cargo.toml` `[dependencies]`.
+    *   `Vertex::desc()`: This associated function returns a `VertexBufferLayout`. This layout descriptor tells `wgpu` how the data within our vertex buffer is structured (the size of each vertex, and the format and offset of each attribute like position and color).
+        *   `array_stride`: The size of one `Vertex` in bytes.
+        *   `step_mode`: `VertexStepMode::Vertex` means the GPU reads one vertex entry per vertex.
+        *   `attributes`: An array describing each field in our `Vertex` struct that will be passed to the vertex shader.
+            *   `shader_location`: Links this attribute to a specific location in the vertex shader (e.g., `layout(location = 0) in vec2<f32> position;`).
+            *   `format`: Specifies the data type and component count (e.g., `Float32x2` is two 32-bit floats).
+
+    **OOP Analogy:** The `Vertex` struct is like a simple data class or Plain Old Data (POD) structure. It defines the "blueprint" for a single point of our geometry. The `desc()` method provides metadata about this blueprint, which the GPU rendering pipeline will use to correctly interpret arrays of these vertex objects.
+
+    If you created `vertex.rs`, make it accessible in `window_test.rs` by adding `mod vertex;` at the top of `window_test.rs` and then `use vertex::Vertex;`.
+
+2.  **Create Shaders (WGSL):**
+    Shaders are small programs that run on the GPU. We need at least two:
+    *   **Vertex Shader:** Processes each vertex. It typically transforms vertex positions from model space to screen space and passes data (like color) to the fragment shader.
+    *   **Fragment Shader (Pixel Shader):** Processes each pixel covered by a primitive (like our triangle). It determines the final color of the pixel.
+
+    Let's create a simple shader file. You can embed this as a string in your Rust code or load it from a file. For simplicity, we'll embed it as a string in `window_test.rs`.
+
+    ```rust
+    // Add this string constant near the top of window_test.rs, or load from a .wgsl file
+    const SHADER_CODE: &str = r#"
+        // Vertex shader
+        struct VertexOutput {
+            @builtin(position) clip_position: vec4<f32>,
+            @location(0) color: vec3<f32>, // Pass color to fragment shader
+        };
+
+        @vertex
+        fn vs_main(
+            @location(0) position: vec2<f32>, // Corresponds to VertexAttribute shader_location 0
+            @location(1) color: vec3<f32>     // Corresponds to VertexAttribute shader_location 1
+        ) -> VertexOutput {
+            var out: VertexOutput;
+            out.clip_position = vec4<f32>(position, 0.0, 1.0); // x, y, z (depth), w (perspective)
+            out.color = color;
+            return out;
+        }
+
+        // Fragment shader
+        @fragment
+        fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+            return vec4<f32>(in.color, 1.0); // Output color (r,g,b) and alpha (1.0 = opaque)
+        }
+    "#;
+    ```
+    *   `struct VertexOutput`: Defines the data structure that the vertex shader will output and the fragment shader will input.
+        *   `@builtin(position) clip_position: vec4<f32>`: Special built-in variable for the vertex's final clip-space position. `wgpu` expects this.
+        *   `@location(0) color: vec3<f32>`: We're passing the vertex color through. The `@location(0)` decorator means this will be the first user-defined varying output/input.
+    *   `@vertex fn vs_main(...)`: The entry point for the vertex shader.
+        *   `@location(0) position: vec2<f32>` and `@location(1) color: vec3<f32>`: These are the inputs from our vertex buffer, matching the `shader_location`s in `Vertex::desc()`.
+        *   `out.clip_position = vec4<f32>(position, 0.0, 1.0);`: We take the 2D input position, set z to 0.0 (no depth for 2D), and w to 1.0 (no perspective division needed for orthographic 2D).
+    *   `@fragment fn fs_main(...)`: The entry point for the fragment shader.
+        *   `in: VertexOutput`: Takes the output from the vertex shader (interpolated for the current pixel).
+        *   `return vec4<f32>(in.color, 1.0);`: Outputs the interpolated color with full alpha.
+
+3.  **Update `WgpuState` for Rendering:**
+    We need to add fields for the render pipeline, vertex buffer, and index buffer to `WgpuState`, and modify `WgpuState::new()` to create them and `WgpuState::render()` to use them.
+
+    ```rust
+    // In window_test.rs
+
+    // If you made vertex.rs, add:
+    // mod vertex;
+    // use vertex::Vertex;
+    // Otherwise, define Vertex struct and its impl Vertex here.
+
+    // Make sure bytemuck is in Cargo.toml: bytemuck = { version = "1.12", features = ["derive"] }
+
+    struct WgpuState {
+        instance: wgpu::Instance,
+        surface: wgpu::Surface<'static>,
+        adapter: wgpu::Adapter,
+        device: wgpu::Device,
+        queue: wgpu::Queue,
+        surface_config: wgpu::SurfaceConfiguration,
+        render_pipeline: wgpu::RenderPipeline, // New
+        vertex_buffer: wgpu::Buffer,         // New
+        index_buffer: wgpu::Buffer,          // New
+        num_indices: u32,                    // New
+    }
+
+    impl WgpuState {
+        async fn new(window: &Window) -> Self {
+            let size = window.inner_size();
+
+            let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { /* ... */ });
+            let surface = instance.create_surface(window).unwrap();
+            let adapter = instance.request_adapter(/* ... */).await.expect("Adapter failed");
+            let (device, queue) = adapter.request_device(/* ... */).await.expect("Device/Queue failed");
+
+            let surface_caps = surface.get_capabilities(&adapter);
+            let surface_format = surface_caps.formats.iter().copied().find(|f| f.is_srgb()).unwrap_or(surface_caps.formats[0]);
+            let surface_config = wgpu::SurfaceConfiguration { /* ... width: size.width, height: size.height ... */ };
+            surface.configure(&device, &surface_config);
+
+            // === NEW CODE FOR RENDERING TRIANGLE ===
+
+            // 1. Create Shader Module
+            let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("Simple Shader"),
+                source: wgpu::ShaderSource::Wgsl(SHADER_CODE.into()),
+            });
+
+            // 2. Create Render Pipeline Layout
+            // This defines any bind groups (for uniforms, textures) the pipeline uses. We don't have any yet.
+            let render_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Render Pipeline Layout"),
+                bind_group_layouts: &[], // No bind groups for now
+                push_constant_ranges: &[], // No push constants for now
+            });
+
+            // 3. Create Render Pipeline
+            let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("Render Pipeline"),
+                layout: Some(&render_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader_module,
+                    entry_point: "vs_main", // Function name in WGSL for vertex shader
+                    buffers: &[Vertex::desc()], // Vertex buffer layout description
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState { // Optional, but needed for outputting color
+                    module: &shader_module,
+                    entry_point: "fs_main", // Function name in WGSL for fragment shader
+                    targets: &[Some(wgpu::ColorTargetState { // Color output configuration
+                        format: surface_config.format, // Must match surface format
+                        blend: Some(wgpu::BlendState::REPLACE), // Replace old pixel data
+                        write_mask: wgpu::ColorWrites::ALL, // Write to all color channels
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList, // Draw triangles
+                    strip_index_format: None, // Not using triangle strips
+                    front_face: wgpu::FrontFace::Ccw, // Counter-clockwise triangles are front-facing
+                    cull_mode: Some(wgpu::Face::Back), // Cull (don't draw) back-facing triangles
+                    polygon_mode: wgpu::PolygonMode::Fill, // Fill triangles, vs. Line or Point
+                    unclipped_depth: false, // Requires specific features
+                    conservative: false, // Requires specific features
+                },
+                depth_stencil: None, // No depth/stencil buffer for now
+                multisample: wgpu::MultisampleState {
+                    count: 1, // No multisampling
+                    mask: !0, // Use all samples
+                    alpha_to_coverage_enabled: false, // For MSAA alpha effects
+                },
+                multiview: None, // Not using multiview rendering
+            });
+
+            // 4. Define Vertex and Index Data
+            // A simple triangle. Coordinates are in Normalized Device Coordinates (NDC)
+            // where (-1, -1) is bottom-left and (1, 1) is top-right.
+            const VERTICES: &[Vertex] = &[
+                Vertex { position: [0.0, 0.5], color: [1.0, 0.0, 0.0] },   // Top, Red
+                Vertex { position: [-0.5, -0.5], color: [0.0, 1.0, 0.0] }, // Bottom-left, Green
+                Vertex { position: [0.5, -0.5], color: [0.0, 0.0, 1.0] },  // Bottom-right, Blue
+            ];
+            // Indices define the order to draw vertices to form triangles.
+            // For a single triangle, it's just 0, 1, 2.
+            const INDICES: &[u16] = &[0, 1, 2];
+
+            // 5. Create Vertex Buffer
+            use wgpu::util::DeviceExt; // For create_buffer_init
+            let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("Vertex Buffer"),
+                contents: bytemuck::cast_slice(VERTICES), // Convert Vertex slice to u8 slice
+                usage: wgpu::BufferUsages::VERTEX, // This buffer will be used as a vertex buffer
+            });
+
+            // 6. Create Index Buffer
+            let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("Index Buffer"),
+                contents: bytemuck::cast_slice(INDICES),
+                usage: wgpu::BufferUsages::INDEX, // This buffer will be used as an index buffer
+            });
+            let num_indices = INDICES.len() as u32;
+
+            // === END OF NEW CODE ===
+
+            Self {
+                instance,
+                surface,
+                adapter,
+                device,
+                queue,
+                surface_config,
+                render_pipeline, // Store new fields
+                vertex_buffer,
+                index_buffer,
+                num_indices,
+            }
+        }
+
+        fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) { /* ... same as before ... */ }
+
+        fn render(&mut self) -> Result<(), wgpu::SurfaceError> {
+            let output_frame = self.surface.get_current_texture()?;
+            let view = output_frame.texture.create_view(&wgpu::TextureViewDescriptor::default());
+            let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Render Encoder"),
+            });
+
+            { // Scoped for render_pass
+                let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("Main Render Pass"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.1, g: 0.2, b: 0.3, a: 1.0 }),
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                });
+
+                // === NEW DRAWING COMMANDS ===
+                render_pass.set_pipeline(&self.render_pipeline); // Set the active pipeline
+                render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..)); // Set vertex buffer for slot 0
+                render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16); // Set index buffer
+                render_pass.draw_indexed(0..self.num_indices, 0, 0..1); // Draw indexed primitives
+                // `0..self.num_indices`: Range of indices to draw
+                // `0`: Base vertex (offset added to each index)
+                // `0..1`: Range of instances (for instanced drawing, we use 1 instance)
+                // === END OF NEW DRAWING COMMANDS ===
+            }
+
+            self.queue.submit(std::iter::once(encoder.finish()));
+            output_frame.present();
+            Ok(())
+        }
+    }
+    // main function remains largely the same, ensure Vertex is in scope and bytemuck is a dependency.
+    // Remember to add `mod vertex;` and `use vertex::Vertex;` if vertex.rs is separate.
+    // And ensure `use wgpu::util::DeviceExt;` is present.
+    ```
+
+    **Key `WgpuState::new()` additions:**
+    *   `device.create_shader_module(...)`: Loads and compiles our WGSL shader code.
+    *   `device.create_pipeline_layout(...)`: Defines the "signature" of the pipeline regarding external resources like textures or uniform buffers. We have none yet.
+    *   `device.create_render_pipeline(...)`: This is a big one. It configures how vertices are processed, how fragments are colored, how primitives are formed, etc. It links our shaders and vertex layout.
+        *   `vertex.buffers: &[Vertex::desc()]`: Crucially links our `Vertex` struct's memory layout to the pipeline.
+        *   `fragment.targets`: Configures how the fragment shader output maps to the surface format.
+        *   `primitive`: Defines how to interpret vertex data (e.g., `TriangleList`).
+    *   `VERTICES` and `INDICES`: Raw data for our triangle.
+    *   `device.create_buffer_init(...)`: A utility from `wgpu::util::DeviceExt` to easily create buffers on the GPU and initialize them with our vertex/index data.
+        *   `bytemuck::cast_slice()`: Safely converts our `&[Vertex]` or `&[u16]` to `&[u8]`.
+        *   `wgpu::BufferUsages::VERTEX` or `wgpu::BufferUsages::INDEX`: Flags the buffer's purpose.
+
+    **Key `WgpuState::render()` additions:**
+    *   `render_pass.set_pipeline(&self.render_pipeline)`: Selects the render pipeline we configured.
+    *   `render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..))`: Binds our vertex buffer to slot 0 (matching `layout(location=0)` in `Vertex::desc()`).
+    *   `render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16)`: Binds our index buffer. `Uint16` matches our `INDICES` data type.
+    *   `render_pass.draw_indexed(0..self.num_indices, 0, 0..1)`: Issues the actual draw call to render `num_indices` worth of vertices, using the bound index and vertex buffers.
+
+    **OOP Analogy:**
+    *   The `RenderPipeline` object is a highly configured "GPU assembly line." It knows exactly how to take raw vertex data, process it through vertex shaders, assemble primitives, and then color them with fragment shaders.
+    *   `VertexBuffer` and `IndexBuffer` are GPU memory objects holding the raw geometric data (the "parts" and "assembly instructions" for our shape).
+    *   The `render_pass` object temporarily "configures" the GPU for a specific set of drawing operations. Calling methods on `render_pass` is like giving instructions to the GPU for that pass.
+
+4.  **Add `bytemuck` Dependency and `DeviceExt`:**
+    Make sure your `GameEng/rust_core/Cargo.toml` has `bytemuck`:
+    ```toml
+    [dependencies]
+    winit = "0.29"
+    wgpu = "0.19"
+    pollster = "0.3"
+    env_logger = "0.10"
+    bytemuck = { version = "1.14", features = ["derive"] } # Check for latest version
+    ```
+    And ensure you have `use wgpu::util::DeviceExt;` at the top of your `window_test.rs` file (or wherever `WgpuState` is defined).
+
+5.  **Run the Custom Geometry Example:**
+    Navigate to `GameEng/rust_core` and run:
+    ```bash
+    cargo run --example window_test
+    ```
+    If all goes well, you should see your window appear, cleared to the dark blue-grey background, AND a brightly colored triangle (Red top, Green bottom-left, Blue bottom-right) drawn in the center!
+
+**Checkpoint 1.4 Summary - CRITICAL SUCCESS!**
+We have successfully rendered custom geometry (a triangle) using a full `wgpu` render pipeline! This includes defining vertex structures, writing WGSL shaders, creating vertex/index buffers, and setting up a render pipeline. This is the most complex part of the initial setup and proves the core rendering capability.
+
+**Next:** We'll refactor this rendering logic into a more organized `render_core` module within our Rust library.
+
+### Checkpoint 1.5: Abstract to `render_core` Module (Rust)
+
+Our `window_test.rs` example is getting quite large. To make our engine more modular and maintainable, we'll refactor the windowing and rendering logic into its own Rust module within our `rust_core` library. This is a common practice in software engineering and aligns well with OOP principles of encapsulation and separation of concerns.
+
+We will create:
+*   `rust_core/src/render_core/mod.rs`: The main file for our new module.
+*   `rust_core/src/render_core/vertex.rs`: We'll move the `Vertex` struct definition here.
+*   `rust_core/src/lib.rs`: We'll expose parts of `render_core` from our library's main file.
+*   The example `window_test.rs` will then use this `render_core` module.
+
+1.  **Create Module Directory and Files:**
+    Inside `GameEng/rust_core/src/`, create a new directory named `render_core`.
+    ```bash
+    # In GameEng/rust_core/src/
+    mkdir render_core
+    ```
+    Move the `vertex.rs` file (if you created it separately) into this new `render_core` directory:
+    ```bash
+    # In GameEng/rust_core/src/
+    mv vertex.rs render_core/vertex.rs
+    # (or copy and delete if mv isn't available/preferred)
+    # If Vertex was defined in window_test.rs, create render_core/vertex.rs and move the struct definition there.
+    ```
+    Create `mod.rs` inside `render_core`:
+    `GameEng/rust_core/src/render_core/mod.rs`
+
+2.  **Populate `render_core/vertex.rs`:**
+    Ensure `GameEng/rust_core/src/render_core/vertex.rs` contains the `Vertex` struct and its `impl` block:
+    ```rust
+    // GameEng/rust_core/src/render_core/vertex.rs
+    #[repr(C)]
+    #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+    pub struct Vertex {
+        pub position: [f32; 2],
+        pub color: [f32; 3],
+    }
+
+    impl Vertex {
+        pub fn desc<'a>() -> wgpu::VertexBufferLayout<'a> {
+            wgpu::VertexBufferLayout {
+                array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
+                step_mode: wgpu::VertexStepMode::Vertex,
+                attributes: &[
+                    wgpu::VertexAttribute {
+                        offset: 0,
+                        shader_location: 0,
+                        format: wgpu::VertexFormat::Float32x2,
+                    },
+                    wgpu::VertexAttribute {
+                        offset: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
+                        shader_location: 1,
+                        format: wgpu::VertexFormat::Float32x3,
+                    },
+                ],
+            }
+        }
+    }
+    ```
+    Notice `pub struct Vertex` and `pub fn desc` – they need to be public to be used from `render_core/mod.rs`.
+
+3.  **Populate `render_core/mod.rs`:**
+    This file will now house the `WgpuState` (perhaps renamed to `Renderer` or `GraphicsContext`) and related logic. We'll also make it responsible for running the event loop.
+
+    ```rust
+    // GameEng/rust_core/src/render_core/mod.rs
+    use winit::{
+        event::{Event, WindowEvent},
+        event_loop::{ControlFlow, EventLoop},
+        window::{Window, WindowBuilder},
+    };
+    use wgpu::util::DeviceExt;
+
+    // Declare vertex as a submodule of render_core
+    mod vertex;
+    // And bring Vertex into scope
+    use vertex::Vertex;
+
+    const SHADER_CODE: &str = r#"
+        // ... (WGSL shader code as before) ...
+        struct VertexOutput {
+            @builtin(position) clip_position: vec4<f32>,
+            @location(0) color: vec3<f32>,
+        };
+
+        @vertex
+        fn vs_main(
+            @location(0) position: vec2<f32>,
+            @location(1) color: vec3<f32>
+        ) -> VertexOutput {
+            var out: VertexOutput;
+            out.clip_position = vec4<f32>(position, 0.0, 1.0);
+            out.color = color;
+            return out;
+        }
+
+        @fragment
+        fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+            return vec4<f32>(in.color, 1.0);
+        }
+    "#;
+
+    // Renamed WgpuState to Renderer for clarity
+    pub struct Renderer {
+        // window: Window, // Window is now owned by run_event_loop, passed by ref
+        surface: wgpu::Surface<'static>, // 'static as window outlives surface within run_event_loop scope
+        #[allow(dead_code)] // instance and adapter might not be used directly after setup
+        instance: wgpu::Instance,
+        #[allow(dead_code)]
+        adapter: wgpu::Adapter,
+        device: wgpu::Device,
+        queue: wgpu::Queue,
+        surface_config: wgpu::SurfaceConfiguration,
+        render_pipeline: wgpu::RenderPipeline,
+        vertex_buffer: wgpu::Buffer,
+        index_buffer: wgpu::Buffer,
+        num_indices: u32,
+    }
+
+    impl Renderer {
+        // Changed signature: takes a reference to an existing window
+        async fn new(window: &Window) -> Self {
+            let size = window.inner_size();
+
+            let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+                backends: wgpu::Backends::PRIMARY,
+                dx12_shader_compiler: Default::default(),
+                flags: Default::default(),
+                gles_minor_version: Default::default(),
+            });
+
+            // Safety: window must be valid for the lifetime of the surface.
+            // In run_event_loop, window is created before Renderer and event_loop.run consumes them.
+            // Renderer is dropped when run_event_loop finishes.
+            let surface = instance.create_surface(window).unwrap();
+
+            let adapter = instance
+                .request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::default(),
+                    compatible_surface: Some(&surface),
+                    force_fallback_adapter: false,
+                })
+                .await
+                .expect("Failed to find a suitable adapter");
+
+            let (device, queue) = adapter
+                .request_device(
+                    &wgpu::DeviceDescriptor {
+                        label: Some("Main Device"),
+                        required_features: wgpu::Features::empty(),
+                        required_limits: wgpu::Limits::default(),
+                        memory_hints: wgpu::MemoryHints::default(),
+                    },
+                    None,
+                )
+                .await
+                .expect("Failed to create device and queue");
+
+            let surface_caps = surface.get_capabilities(&adapter);
+            let surface_format = surface_caps.formats.iter()
+                .copied()
+                .find(|f| f.is_srgb())
+                .unwrap_or(surface_caps.formats[0]);
+
+            let surface_config = wgpu::SurfaceConfiguration {
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                format: surface_format,
+                width: size.width.max(1), // Ensure width is at least 1
+                height: size.height.max(1), // Ensure height is at least 1
+                present_mode: surface_caps.present_modes[0], // Fifo (vsync)
+                alpha_mode: surface_caps.alpha_modes[0],
+                view_formats: vec![],
+                desired_maximum_frame_latency: 2,
+            };
+            surface.configure(&device, &surface_config);
+
+            // Shader, pipeline layout, pipeline, buffers (same as before)
+            let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("Simple Shader"),
+                source: wgpu::ShaderSource::Wgsl(SHADER_CODE.into()),
+            });
+
+            let render_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Render Pipeline Layout"),
+                bind_group_layouts: &[],
+                push_constant_ranges: &[],
+            });
+
+            let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("Render Pipeline"),
+                layout: Some(&render_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader_module,
+                    entry_point: "vs_main",
+                    buffers: &[Vertex::desc()],
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader_module,
+                    entry_point: "fs_main",
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: surface_config.format,
+                        blend: Some(wgpu::BlendState::REPLACE),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    strip_index_format: None,
+                    front_face: wgpu::FrontFace::Ccw,
+                    cull_mode: Some(wgpu::Face::Back),
+                    polygon_mode: wgpu::PolygonMode::Fill,
+                    unclipped_depth: false,
+                    conservative: false,
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(), // Simpler default
+                multiview: None,
+            });
+
+            const VERTICES: &[Vertex] = &[
+                Vertex { position: [0.0, 0.5], color: [1.0, 0.0, 0.0] },
+                Vertex { position: [-0.5, -0.5], color: [0.0, 1.0, 0.0] },
+                Vertex { position: [0.5, -0.5], color: [0.0, 0.0, 1.0] },
+            ];
+            const INDICES: &[u16] = &[0, 1, 2];
+
+            let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("Vertex Buffer"),
+                contents: bytemuck::cast_slice(VERTICES),
+                usage: wgpu::BufferUsages::VERTEX,
+            });
+
+            let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("Index Buffer"),
+                contents: bytemuck::cast_slice(INDICES),
+                usage: wgpu::BufferUsages::INDEX,
+            });
+            let num_indices = INDICES.len() as u32;
+
+            Self {
+                instance,
+                surface,
+                adapter,
+                device,
+                queue,
+                surface_config,
+                render_pipeline,
+                vertex_buffer,
+                index_buffer,
+                num_indices,
+            }
+        }
+
+        pub fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
+            if new_size.width > 0 && new_size.height > 0 {
+                self.surface_config.width = new_size.width;
+                self.surface_config.height = new_size.height;
+                self.surface.configure(&self.device, &self.surface_config);
+            }
+        }
+
+        // Input method for window events, not strictly necessary if event loop is managed here
+        // pub fn input(&mut self, _event: &WindowEvent) -> bool {
+        //     false // Return true if the event was handled
+        // }
+
+        pub fn render(&mut self) -> Result<(), wgpu::SurfaceError> {
+            let output_frame = self.surface.get_current_texture()?;
+            let view = output_frame.texture.create_view(&wgpu::TextureViewDescriptor::default());
+            let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Render Encoder"),
+            });
+
+            {
+                let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("Main Render Pass"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.1, g: 0.2, b: 0.3, a: 1.0 }),
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                });
+
+                render_pass.set_pipeline(&self.render_pipeline);
+                render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+                render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+                render_pass.draw_indexed(0..self.num_indices, 0, 0..1);
+            }
+
+            self.queue.submit(std::iter::once(encoder.finish()));
+            output_frame.present();
+            Ok(())
+        }
+    }
+
+    // This function will be the main public entry point for starting the renderer
+    pub async fn run() {
+        env_logger::init();
+        let event_loop = EventLoop::new().unwrap();
+        let window = WindowBuilder::new()
+            .with_title("Rust Core Engine - Render Module Test")
+            .with_inner_size(winit::dpi::LogicalSize::new(800.0, 600.0))
+            .build(&event_loop)
+            .unwrap();
+
+        // The window is created here and its reference is passed to Renderer::new.
+        // `Renderer` does not own `window`. `window` will be moved into the event_loop.run closure.
+        // The `surface` inside `Renderer` uses `SurfaceTarget::Window(Arc<Window>)` implicitly if from_window is used,
+        // or if created with `create_surface(&window)`, the `window` ref must outlive `surface`.
+        // Here, `window` (owned by this scope) outlives `renderer` (also owned by this scope before being moved).
+        // The `Arc<Window>` approach is safer if `Renderer` needs to be passed around more freely.
+        // For this example, creating surface with `create_surface(&window)` and ensuring lifetimes are managed by scope is okay.
+        // To make `surface` truly `'static` as per its type signature for simplicity, we can wrap `window` in `Arc`
+        // if we were to pass `Renderer` around, but here it's fine as `window` outlives `Renderer` effectively.
+        // Let's use a reference to the window for creating the surface, and ensure window is moved into closure.
+
+        let window_id = window.id(); // Get window ID before moving window
+        let mut renderer = Renderer::new(&window).await; // Pass window by reference
+
+        let _ = event_loop.run(move |event, elwt| {
+            elwt.set_control_flow(ControlFlow::Wait);
+
+            match event {
+                Event::WindowEvent { event, window_id: current_window_id } if current_window_id == window_id => {
+                    match event {
+                        WindowEvent::CloseRequested => elwt.exit(),
+                        WindowEvent::Resized(physical_size) => {
+                            renderer.resize(physical_size);
+                        }
+                        WindowEvent::RedrawRequested => {
+                            match renderer.render() {
+                                Ok(_) => {}
+                                Err(wgpu::SurfaceError::Lost) => renderer.resize(window.inner_size()), // Use window from closure
+                                Err(wgpu::SurfaceError::OutOfMemory) => elwt.exit(),
+                                Err(e) => eprintln!("Error during render: {:?}", e),
+                            }
+                        }
+                        _ => (),
+                    }
+                }
+                Event::AboutToWait => {
+                    // Request redraw only for our window
+                    // This requires `window` to be accessible here. It is, as it was moved into the closure.
+                    window.request_redraw();
+                }
+                _ => (),
+            }
+        });
+    }
+    ```
+    **Key Changes in `render_core/mod.rs`:**
+    *   `mod vertex; use vertex::Vertex;`: Declares `vertex.rs` as a submodule and brings `Vertex` into scope.
+    *   `pub struct Renderer`: `WgpuState` is renamed to `Renderer` and made public. Some fields like `instance` and `adapter` are marked `#[allow(dead_code)]` if they are not used after initialization within this module.
+    *   `Renderer::new(window: &Window)`: Now takes a reference to a `winit::window::Window`. The `surface` is created using this reference. The lifetime `'static` for `surface: wgpu::Surface<'static>` is a simplification. In a real scenario with `Renderer` being passed around, you'd typically use `Arc<Window>` when creating the surface or manage lifetimes carefully. For our structure where `run()` creates the window and renderer and then consumes them in the event loop, this is acceptable.
+    *   `pub fn resize`, `pub fn render`: These methods are made public.
+    *   `pub async fn run()`: This new public asynchronous function encapsulates the event loop creation, window building, `Renderer` initialization, and running the event loop. This will be the primary way to start our renderer from outside.
+        *   The `window` is created within `run` and its reference is passed to `Renderer::new`. Then `window` is moved into the `event_loop.run` closure. This ensures `window` outlives the `Renderer`'s use of it for surface creation and is available for `request_redraw`.
+
+4.  **Update `rust_core/src/lib.rs`:**
+    This file is the entry point for our `rust_core` library. We need to declare `render_core` as a public module here.
+
+    ```rust
+    // GameEng/rust_core/src/lib.rs
+
+    // Declare render_core as a public module of the rust_core crate
+    pub mod render_core;
+
+    // You could also re-export specific items if desired, e.g.:
+    // pub use render_core::run_renderer; // If you rename run to run_renderer
+
+    // Previous content (get_initial_message and tests) can remain or be removed
+    // if this library is solely for the render_core now.
+    // For now, let's keep it to show how modules coexist.
+    pub fn get_initial_message() -> String {
+        "Rust Core Library Initialized! (Now with a render_core module)".to_string()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn it_works() {
+            let result = get_initial_message();
+            assert_eq!(result, "Rust Core Library Initialized! (Now with a render_core module)");
+        }
+        // You could add tests for render_core functionality here too,
+        // though they might be harder to automate without visual inspection or specific test setups.
+    }
+    ```
+
+5.  **Update `rust_core/src/examples/window_test.rs`:**
+    Now, our example will be much simpler. It will just call the `run` function from our new `render_core` module.
+
+    ```rust
+    // GameEng/rust_core/src/examples/window_test.rs
+
+    // Use the run function from our rust_core library's render_core module
+    use rust_core::render_core;
+
+    fn main() {
+        // pollster is still needed here if render_core::run() is async
+        // and main itself is not async.
+        // If render_core::run becomes the top-level async entry,
+        // it might handle its own blocking or be called from an async runtime.
+        // For consistency with how `run` is defined as async:
+        pollster::block_on(render_core::run());
+    }
+    ```
+    *   `use rust_core::render_core;`: Imports the `render_core` module from our library.
+    *   `pollster::block_on(render_core::run());`: Calls the public `run` function.
+
+6.  **Run the Example:**
+    Navigate to `GameEng/rust_core` in your terminal:
+    ```bash
+    cargo run --example window_test
+    ```
+    The output should be identical to Checkpoint 1.4: a window with a colored triangle. However, the code is now much better organized.
+    *   The core rendering logic is encapsulated within the `render_core` module.
+    *   Our library `rust_core` exposes this `render_core`.
+    *   The example `window_test.rs` is now a simple consumer of this module.
+
+**Checkpoint 1.5 Summary:**
+We've successfully refactored our rendering code into a dedicated `render_core` module. This improves code organization, encapsulation, and reusability, aligning with good software engineering and OOP principles. The `Renderer` struct acts like a class responsible for all graphics operations.
+
+**OOP Analogy:** We've essentially created a `RenderSystem` or `GraphicsEngine` module (`render_core`). Inside it, the `Renderer` struct acts as the main class, encapsulating all the complex state and logic for drawing. The `run()` function is like a static method or a factory that sets up and starts this system. Our example program now just tells this "RenderSystem" to start, without needing to know all the intricate details of how it works internally. This is a prime example of abstraction.
+
+**Phase 1 Complete!** We have a Rust core capable of opening a window and rendering custom geometry, all neatly organized. This is a huge milestone.
+
+**Next:** Phase 2 - Python Setup & Basic Bindings, where we'll connect Python to our Rust core.
+
+## Phase 2: Python Integration - Bridging the Gap
+
+With our Rust core capable of rendering, the next crucial step is to bridge the gap to Python. We want to be able to call Rust functions from Python and exchange data between the two. This is where PyO3 comes in. PyO3 is a set of Rust bindings for Python, allowing seamless interoperability.
+
+**Object-Oriented Programming (OOP) Analogy:**
+Think of PyO3 as a universal adapter or a translator. Our "Rust machine" speaks Rust, and our "scripting console" speaks Python. PyO3 allows these two distinct systems to communicate effectively, almost as if Python objects were calling methods on Rust objects, and vice-versa. We'll be able to expose Rust structs with `impl` blocks as Python classes with methods.
+
+### Checkpoint 2.1: Python Project Setup
+
+First, let's set up a basic Python project structure and environment.
+
+1.  **Create Python Project Directory:**
+    In your main `GameEng` directory (alongside `rust_core`), create a directory for Python scripts:
+    ```bash
+    # In GameEng/
+    mkdir python_scripts
+    cd python_scripts
+    ```
+
+2.  **Set Up a Python Virtual Environment:**
+    It's highly recommended to use a virtual environment for each Python project to manage its dependencies independently. If you haven't already, create one inside `GameEng` (or `python_scripts` if you prefer, but `GameEng` is common for project-wide venvs).
+
+    ```bash
+    # In GameEng/
+    python3 -m venv venv
+    ```
+    Activate it:
+    *   **Windows (Git Bash or similar):** `source venv/Scripts/activate`
+    *   **Windows (Command Prompt/PowerShell):** `venv\Scripts\activate`
+    *   **macOS/Linux:** `source venv/bin/activate`
+    Your terminal prompt should now be prefixed with `(venv)`.
+
+3.  **Create `main_controller.py`:**
+    Inside `GameEng/python_scripts/`, create a simple Python script that will eventually interact with our Rust core.
+    `GameEng/python_scripts/main_controller.py`:
+    ```python
+    # GameEng/python_scripts/main_controller.py
+
+    def main():
+        print("Python main_controller.py initialized.")
+        print("Attempting to import Rust module...")
+        # We'll add Rust import and calls here later
+
+    if __name__ == "__main__":
+        main()
+    ```
+
+4.  **Create `requirements.txt`:**
+    While we don't have Python-specific dependencies *yet* besides what PyO3 will provide, it's good practice to have this file.
+    Create an empty `GameEng/requirements.txt` for now. We might add things like `numpy` or UI libraries later.
+
+5.  **Test Python Setup:**
+    Make sure your virtual environment is active (`(venv)` is in your prompt).
+    Navigate to the `GameEng` directory (the parent of `python_scripts`) and run:
+    ```bash
+    python python_scripts/main_controller.py
+    ```
+    You should see:
+    ```
+    Python main_controller.py initialized.
+    Attempting to import Rust module...
+    ```
+    This confirms your basic Python script is runnable.
+
+**Checkpoint 2.1 Summary:**
+We've established a directory for our Python scripts, set up a virtual environment, and created a basic `main_controller.py` script. Our Python side is ready to be connected to Rust.
+
+### Checkpoint 2.2: Basic PyO3 Binding Setup
+
+Now we'll configure our Rust `rust_core` library to be callable from Python using PyO3. This involves:
+1.  Adding `pyo3` as a dependency in `Cargo.toml`.
+2.  Modifying `Cargo.toml` to specify that we want to build a Python extension module (a dynamic library).
+3.  Using PyO3 macros in `rust_core/src/lib.rs` to expose Rust functions to Python.
+4.  Building the Rust library and importing it into Python.
+
+1.  **Add PyO3 Dependency and Configure `Cargo.toml`:**
+    Open `GameEng/rust_core/Cargo.toml`.
+    *   Add `pyo3` to the `[dependencies]` section. The `extension-module` feature is important as it tells PyO3 we're building a module to be imported by Python.
+    *   Add a `[lib]` section to configure the crate type for a dynamic system library (`cdylib`), which is what Python needs for extensions. We also can specify the library name here, which will be the name Python uses to import it.
+
+    ```toml
+    # GameEng/rust_core/Cargo.toml
+    [package]
+    name = "rust_core" # This name is used by Rust internally
+    version = "0.1.0"
+    edition = "2021"
+
+    [lib]
+    name = "dmtk_engine_rust"  # This will be the name of the .so/.pyd/.dylib file
+                              # Python will use `import dmtk_engine_rust`
+    crate-type = ["cdylib"]   # Compile to a C-style dynamic library
+
+    [dependencies]
+    winit = "0.29"
+    wgpu = "0.19" # Make sure versions are consistent with previous steps
+    pollster = "0.3"
+    env_logger = "0.10"
+    bytemuck = { version = "1.14", features = ["derive"] }
+
+    pyo3 = { version = "0.20", features = ["extension-module"] } # Check for latest PyO3 version
+    ```
+    *   **`[lib].name`**: This is crucial. It defines the actual filename of the compiled library (e.g., `dmtk_engine_rust.so` on Linux, `dmtk_engine_rust.pyd` on Windows). Python will use this name for importing.
+    *   **`[lib].crate-type = ["cdylib"]`**: This tells Rust to compile our library into a format that can be loaded by other languages like Python.
+    *   **`pyo3 features = ["extension-module"]`**: This enables PyO3 features necessary for building an extension that Python can directly import.
+
+2.  **Expose Rust Functions in `rust_core/src/lib.rs`:**
+    We'll use PyO3's procedural macros (`#[pyfunction]`, `#[pymodule]`) to mark Rust functions and modules for exposure to Python.
+
+    Let's modify `GameEng/rust_core/src/lib.rs`:
+
+    ```rust
+    // GameEng/rust_core/src/lib.rs
+    use pyo3::prelude::*; // Import PyO3 macros and types
+
+    pub mod render_core; // Keep our render_core module
+
+    // This is the function we had before, let's expose it.
+    #[pyfunction] // Exposes this Rust function to Python
+    fn get_engine_version() -> PyResult<String> {
+        Ok("DMTK Engine (Rust Core) v0.0.1".to_string())
+    }
+
+    // A new function that uses our render_core (though it won't show window yet from Python this way)
+    // We'll need a different approach to run the event loop from Python control later.
+    // For now, this demonstrates calling into a module.
+    #[pyfunction]
+    fn launch_render_window() -> PyResult<()> {
+        // For PyO3 functions that might block or run an event loop,
+        // it's usually better to run them in a separate thread from Python
+        // or use Python's async capabilities if PyO3 supports it for that function.
+        // Directly calling pollster::block_on here would block the Python interpreter.
+        // For now, let's just print a message.
+        // In a real scenario, you'd likely have Python call a function that *configures* the renderer,
+        // and then another Python call to *start* it, potentially in a non-blocking way.
+
+        println!("launch_render_window called from Python (not actually launching window yet from this binding).");
+        // To actually run it (and block Python):
+        // pollster::block_on(render_core::run());
+        // This would work but freeze Python until the window is closed.
+        // We will explore better ways to integrate the event loop later.
+        Ok(())
+    }
+
+
+    // This function defines the Python module.
+    // The name of the function (e.g., `dmtk_engine_rust`) MUST match the `[lib].name` in Cargo.toml.
+    #[pymodule]
+    #[pyo3(name = "dmtk_engine_rust")] // Optional: explicitly set Python module name if different from fn name
+    fn dmtk_engine_rust_py(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+        m.add_function(wrap_pyfunction!(get_engine_version, m)?)?;
+        m.add_function(wrap_pyfunction!(launch_render_window, m)?)?;
+        // We could also add submodules here if render_core exposed PyO3 functions/classes
+        // e.g., m.add_wrapped(wrap_pymodule!(render_core::python_bindings::render_module))?;
+        Ok(())
+    }
+
+    // Old test code (can be kept or removed)
+    #[cfg(test)]
+    mod tests {
+        // Note: PyO3 specific tests often require a Python interpreter context.
+        // Standard Rust tests for non-PyO3 parts are fine.
+        #[test]
+        fn basic_test() {
+            assert_eq!(2 + 2, 4);
+        }
+    }
+    ```
+    *   `use pyo3::prelude::*;`: Imports commonly used PyO3 items.
+    *   `#[pyfunction]`: This attribute macro makes a Rust function callable from Python. The function must return `PyResult<T>` (or `T` if `T` implements `IntoPy<PyObject>`).
+    *   `#[pymodule]`: This attribute macro on a function defines the entry point for the Python module.
+        *   The function name (e.g., `dmtk_engine_rust_py`) is conventional but the `#[pyo3(name = "dmtk_engine_rust")]` attribute is what truly defines the module name if you want it different from the Rust function name. However, it's simpler if the Rust function name itself matches the `[lib].name` in `Cargo.toml`. For this tutorial, we'll ensure the function name *is* `dmtk_engine_rust`.
+        *   `_py: Python`: A token representing the Python interpreter's global state (GIL).
+        *   `m: &Bound<'_, PyModule>`: A reference to the Python module object being created.
+        *   `m.add_function(wrap_pyfunction!(get_engine_version, m)?)?`: Adds our exposed Rust function to the Python module.
+    *   **Important Note on `launch_render_window`:** Directly running an event loop like `render_core::run()` from a simple PyO3-bound function will block the Python interpreter until the Rust window is closed. This is usually not desired. For this checkpoint, we'll just have it print a message. Proper integration of a Rust event loop with Python often involves running the Rust part in a separate thread or using more advanced async/await patterns with PyO3 if available and suitable. We will address this more deeply when we want Python to control the game loop that includes rendering.
+
+3.  **Build the Rust Extension Module:**
+    Now, we need to compile our Rust library into the dynamic library format that Python can load.
+    *   Ensure your Python virtual environment (e.g., `venv`) is **active**. This is important because `pyo3` sometimes uses it to find Python headers or link correctly.
+    *   Navigate to your `GameEng/rust_core` directory in the terminal.
+    *   Run the build command:
+        ```bash
+        cargo build --release
+        ```
+        *   `--release`: Builds an optimized version of the library. For development, you can omit this, but release builds are generally faster.
+        *   This will create the library file in `GameEng/rust_core/target/release/`. The file will be named something like:
+            *   Linux: `libdmtk_engine_rust.so`
+            *   Windows: `dmtk_engine_rust.dll` (cargo might also produce a `dmtk_engine_rust.pyd`, which is just a renamed .dll for Python)
+            *   macOS: `libdmtk_engine_rust.dylib`
+
+4.  **Make the Module Available to Python:**
+    Python needs to be able to find this compiled file. There are a few ways:
+    *   **Copy/Symlink to Python Path:** Copy or symlink the compiled file (e.g., `libdmtk_engine_rust.so`) into a directory that's on Python's import path, like your `GameEng/python_scripts/` directory or your virtual environment's `site-packages` directory.
+        *   On Linux/macOS, you'd rename `libdmtk_engine_rust.so` or `libdmtk_engine_rust.dylib` to `dmtk_engine_rust.so` (Python on these systems often expects `.so` for extensions, or it finds the dylib correctly).
+        *   On Windows, you'd rename `dmtk_engine_rust.dll` to `dmtk_engine_rust.pyd`.
+    *   **Using `maturin` (Recommended for Development):** `maturin` is a tool specifically for building and publishing Rust-Python packages. It handles the compilation and places the output in the correct location for Python to import it, often by building a "wheel" and installing it.
+        *   Install maturin (with venv active): `pip install maturin`
+        *   In `GameEng/rust_core/`, run: `maturin develop --release` (or just `maturin develop` for debug builds)
+        This command compiles your Rust code and installs it into your current Python virtual environment, making it directly importable. This is the most convenient method for development.
+
+    **For this tutorial, let's use `maturin` as it's the cleanest.**
+    *   If you haven't already, activate your venv: `source ../venv/bin/activate` (if you are in `rust_core`)
+    *   Install maturin: `pip install maturin`
+    *   Build and install into venv:
+        ```bash
+        # Ensure you are in GameEng/rust_core/
+        maturin develop --release
+        ```
+        You should see output indicating a successful build and installation.
+
+5.  **Test Importing in Python:**
+    Now, modify `GameEng/python_scripts/main_controller.py` to import and use our Rust module.
+
+    ```python
+    # GameEng/python_scripts/main_controller.py
+
+    # The name "dmtk_engine_rust" comes from [lib].name in Cargo.toml
+    import dmtk_engine_rust
+
+    def main():
+        print("Python main_controller.py initialized.")
+        print("Attempting to import and use Rust module...")
+
+        try:
+            version = dmtk_engine_rust.get_engine_version()
+            print(f"Successfully called Rust! Engine Version: {version}")
+
+            print("Attempting to call launch_render_window from Rust...")
+            dmtk_engine_rust.launch_render_window() # This will just print for now
+            print("launch_render_window returned to Python.")
+
+        except ImportError:
+            print("Error: Could not import the 'dmtk_engine_rust' module.")
+            print("Make sure you have built it with `maturin develop` in the rust_core directory.")
+        except Exception as e:
+            print(f"An error occurred: {e}")
+
+    if __name__ == "__main__":
+        main()
+    ```
+
+6.  **Run the Python Script:**
+    Make sure your virtual environment is active. Navigate to `GameEng/` and run:
+    ```bash
+    python python_scripts/main_controller.py
+    ```
+    You should see output like this:
+    ```
+    Python main_controller.py initialized.
+    Attempting to import and use Rust module...
+    Successfully called Rust! Engine Version: DMTK Engine (Rust Core) v0.0.1
+    Attempting to call launch_render_window from Rust...
+    launch_render_window called from Python (not actually launching window yet from this binding).
+    launch_render_window returned to Python.
+    ```
+
+**Checkpoint 2.2 Summary:**
+Success! We've configured our Rust project with PyO3, exposed Rust functions, compiled it as a Python extension module using `maturin`, and successfully called those Rust functions from our Python script. The bridge between Rust and Python is now open!
+
+**Next:** We'll explore passing more complex data (like simple numbers and strings) from Python to Rust and back.
+
+### Checkpoint 2.3: Data Passing (Python -> Rust)
+
+Now that we can call Rust functions from Python, let's pass some data. PyO3 handles conversions for many common types automatically. We'll create a Rust function that accepts simple arguments (like numbers and strings) from Python.
+
+1.  **Define a Rust Function that Accepts Arguments:**
+    Open `GameEng/rust_core/src/lib.rs` and add a new `#[pyfunction]` that takes arguments.
+
+    ```rust
+    // GameEng/rust_core/src/lib.rs
+    use pyo3::prelude::*;
+
+    pub mod render_core;
+
+    #[pyfunction]
+    fn get_engine_version() -> PyResult<String> {
+        Ok("DMTK Engine (Rust Core) v0.0.1".to_string())
+    }
+
+    #[pyfunction]
+    fn launch_render_window() -> PyResult<()> {
+        println!("launch_render_window called from Python (not actually launching window yet from this binding).");
+        Ok(())
+    }
+
+    // New function to demonstrate passing data from Python to Rust
+    #[pyfunction]
+    fn process_data_from_python(name: String, count: i32, active: bool) -> PyResult<String> {
+        println!("[Rust] Received data from Python:");
+        println!("[Rust]   Name: {}", name);
+        println!("[Rust]   Count: {}", count);
+        println!("[Rust]   Active: {}", active);
+
+        let response = format!(
+            "Rust received: Name='{}', Count={}, Active={}. Processed successfully!",
+            name, count, active
+        );
+        Ok(response)
+    }
+
+    #[pymodule]
+    #[pyo3(name = "dmtk_engine_rust")]
+    fn dmtk_engine_rust_py(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+        m.add_function(wrap_pyfunction!(get_engine_version, m)?)?;
+        m.add_function(wrap_pyfunction!(launch_render_window, m)?)?;
+        m.add_function(wrap_pyfunction!(process_data_from_python, m)?)?; // Add the new function
+        Ok(())
+    }
+
+    // ... (tests module)
+    ```
+    *   `fn process_data_from_python(name: String, count: i32, active: bool)`:
+        *   This function now takes a Rust `String`, an `i32` (32-bit signed integer), and a `bool`.
+        *   PyO3 will automatically convert Python strings to Rust `String`, Python integers to Rust `i32` (if they fit, otherwise it might error or require explicit type hints in Python), and Python booleans to Rust `bool`.
+        *   It prints the received values to the console (prefixed with `[Rust]`) to show they arrived correctly.
+        *   It returns a `PyResult<String>` which will be converted back to a Python string.
+    *   Remember to add `process_data_from_python` to the `#[pymodule]` function using `m.add_function(...)`.
+
+2.  **Rebuild with Maturin:**
+    Since we've changed the Rust code, we need to recompile and reinstall the module into our Python environment.
+    *   Ensure your Python virtual environment is active.
+    *   In `GameEng/rust_core/`, run:
+        ```bash
+        maturin develop --release
+        # Or just `maturin develop` for a faster debug build during iteration
+        ```
+
+3.  **Call the New Function from Python:**
+    Modify `GameEng/python_scripts/main_controller.py` to call this new function with some data.
+
+    ```python
+    # GameEng/python_scripts/main_controller.py
+    import dmtk_engine_rust
+
+    def main():
+        print("Python main_controller.py initialized.")
+        print("Attempting to import and use Rust module...")
+
+        try:
+            version = dmtk_engine_rust.get_engine_version()
+            print(f"Successfully called Rust! Engine Version: {version}")
+
+            print("\nAttempting to call launch_render_window from Rust...")
+            dmtk_engine_rust.launch_render_window()
+            print("launch_render_window returned to Python.")
+
+            print("\nAttempting to pass data to Rust function 'process_data_from_python'...")
+            python_name = "PlayerOne"
+            python_count = 100
+            python_active = True
+
+            response_from_rust = dmtk_engine_rust.process_data_from_python(
+                python_name,
+                python_count,
+                python_active
+            )
+            print(f"[Python] Received response from Rust: {response_from_rust}")
+
+        except ImportError:
+            print("Error: Could not import the 'dmtk_engine_rust' module.")
+            print("Make sure you have built it with `maturin develop` in the rust_core directory.")
+        except Exception as e:
+            print(f"An error occurred: {e}")
+
+    if __name__ == "__main__":
+        main()
+    ```
+
+4.  **Run the Python Script:**
+    Ensure your virtual environment is active. Navigate to `GameEng/` and run:
+    ```bash
+    python python_scripts/main_controller.py
+    ```
+    You should see output similar to this:
+    ```
+    Python main_controller.py initialized.
+    Attempting to import and use Rust module...
+    Successfully called Rust! Engine Version: DMTK Engine (Rust Core) v0.0.1
+
+    Attempting to call launch_render_window from Rust...
+    launch_render_window called from Python (not actually launching window yet from this binding).
+    launch_render_window returned to Python.
+
+    Attempting to pass data to Rust function 'process_data_from_python'...
+    [Rust] Received data from Python:
+    [Rust]   Name: PlayerOne
+    [Rust]   Count: 100
+    [Rust]   Active: true
+    [Python] Received response from Rust: Rust received: Name='PlayerOne', Count=100, Active=true. Processed successfully!
+    ```
+    Notice the `[Rust]` prefixed lines, confirming that the Rust function received the data correctly from Python. The final line shows Python receiving the formatted string back from Rust.
+
+**Supported Types:**
+PyO3 supports automatic conversion for many common types between Python and Rust, including:
+*   Numeric types (`i8` through `i64`, `u8` through `u64`, `isize`, `usize`, `f32`, `f64`) <-> Python `int` and `float`.
+*   `bool` <-> Python `bool`.
+*   `String`, `&str` <-> Python `str`.
+*   `Vec<T>` <-> Python `list` (if `T` is convertible).
+*   `HashMap<K, V>` <-> Python `dict` (if `K` and `V` are convertible).
+*   `Option<T>` <-> Python `None` or the value of `T`.
+*   Tuples <-> Python `tuple`.
+And many more, including custom types using `#[pyclass]`, which we'll see next.
+
+**Checkpoint 2.3 Summary:**
+We have successfully passed basic data types (string, integer, boolean) from Python to a Rust function. The Rust function processed this data and returned a string confirmation to Python. This demonstrates bidirectional communication for simple data.
+
+**Next:** We'll explore how to pass more structured data by defining Rust structs that can be converted to Python objects (classes) and vice-versa.
+
+### Checkpoint 2.4: Data Passing (Rust Structs <-> Python Classes)
+
+A powerful feature of PyO3 is its ability to expose Rust structs as Python classes. This allows for a more idiomatic and object-oriented way of interacting with Rust code from Python.
+
+1.  **Define a Rust Struct with `#[pyclass]`:**
+    Open `GameEng/rust_core/src/lib.rs`. We'll define a new struct `EngineStatus` and use `#[pyclass]` to make it usable as a Python class. We'll also implement methods for it using `#[pymethods]`.
+
+    ```rust
+    // GameEng/rust_core/src/lib.rs
+    use pyo3::prelude::*;
+
+    pub mod render_core; // Keep our render_core module
+
+    // --- Existing PyFunctions ---
+    #[pyfunction]
+    fn get_engine_version() -> PyResult<String> {
+        Ok("DMTK Engine (Rust Core) v0.0.1".to_string())
+    }
+
+    #[pyfunction]
+    fn launch_render_window() -> PyResult<()> {
+        println!("launch_render_window called from Python (not actually launching window yet from this binding).");
+        Ok(())
+    }
+
+    #[pyfunction]
+    fn process_data_from_python(name: String, count: i32, active: bool) -> PyResult<String> {
+        println!("[Rust] Received data from Python:");
+        println!("[Rust]   Name: {}", name);
+        println!("[Rust]   Count: {}", count);
+        println!("[Rust]   Active: {}", active);
+        let response = format!(
+            "Rust received: Name='{}', Count={}, Active={}. Processed successfully!",
+            name, count, active
+        );
+        Ok(response)
+    }
+
+    // --- New PyClass: EngineStatus ---
+    #[pyclass] // This attribute makes the Rust struct usable as a Python class
+    #[derive(Debug, Clone)] // Clone is useful if Python code needs to copy the object
+    struct EngineStatus {
+        #[pyo3(get, set)] // Expose 'version' field as a Python property (getter and setter)
+        version: String,
+
+        #[pyo3(get, set)] // Expose 'is_ready' field as a Python property
+        is_ready: bool,
+
+        // This field will not be directly accessible from Python unless exposed
+        internal_code: i32,
+    }
+
+    #[pymethods] // Implementation block for methods exposed to Python
+    impl EngineStatus {
+        #[new] // This defines the constructor for the Python class
+        fn new(version: String, is_ready: bool) -> Self {
+            println!("[Rust] EngineStatus constructor called from Python.");
+            EngineStatus {
+                version,
+                is_ready,
+                internal_code: 42, // Initialize internal field
+            }
+        }
+
+        // An example method callable from Python
+        fn get_status_summary(&self) -> PyResult<String> {
+            Ok(format!(
+                "EngineStatus: Version '{}', Ready: {}, Internal Code: {}",
+                self.version, self.is_ready, self.internal_code
+            ))
+        }
+
+        // A method to modify internal state, showing interaction
+        fn set_internal_code_plus_one(&mut self) -> PyResult<()> {
+            self.internal_code += 1;
+            println!("[Rust] internal_code incremented to: {}", self.internal_code);
+            Ok(())
+        }
+    }
+
+    // --- New PyFunction to return an EngineStatus instance ---
+    #[pyfunction]
+    fn get_current_engine_status() -> PyResult<EngineStatus> {
+        println!("[Rust] get_current_engine_status called.");
+        Ok(EngineStatus {
+            version: "0.1.0-alpha".to_string(),
+            is_ready: false,
+            internal_code: 101,
+        })
+    }
+
+    // --- Function to receive an EngineStatus instance from Python ---
+    #[pyfunction]
+    fn inspect_engine_status_from_python(status: &EngineStatus) -> PyResult<()> {
+        // Note: We take EngineStatus by reference (&EngineStatus)
+        // PyO3 handles the conversion from a Python instance of the class.
+        println!("[Rust] Received EngineStatus from Python:");
+        println!("[Rust]   Version: {}", status.version);
+        println!("[Rust]   Is Ready: {}", status.is_ready);
+        // We can't directly access status.internal_code here if it's not pub or via a getter in Rust.
+        // However, if we called a method like status.get_status_summary(), it would use the internal_code.
+        // For direct field access in Rust, the field needs to be public or accessed via a Rust getter.
+        // The `#[pyo3(get)]` makes it accessible from Python, not necessarily from other Rust code via this reference.
+        // To demonstrate internal access, let's use the debug print:
+        println!("[Rust]   Full Debug: {:?}", status);
+        Ok(())
+    }
+
+
+    // --- Update Python Module Definition ---
+    #[pymodule]
+    #[pyo3(name = "dmtk_engine_rust")]
+    fn dmtk_engine_rust_py(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+        m.add_function(wrap_pyfunction!(get_engine_version, m)?)?;
+        m.add_function(wrap_pyfunction!(launch_render_window, m)?)?;
+        m.add_function(wrap_pyfunction!(process_data_from_python, m)?)?;
+
+        m.add_class::<EngineStatus>()?; // Add the EngineStatus class to the Python module
+        m.add_function(wrap_pyfunction!(get_current_engine_status, m)?)?;
+        m.add_function(wrap_pyfunction!(inspect_engine_status_from_python, m)?)?;
+        Ok(())
+    }
+    // ... (tests module)
+    ```
+    *   **`#[pyclass]`**: Marks `EngineStatus` as a type that can be exposed to Python.
+        *   `#[derive(Debug, Clone)]`: Useful for debugging in Rust and allowing Python to potentially clone the object if needed (though direct cloning behavior in Python needs more setup).
+    *   **`#[pyo3(get, set)]`**: Applied to fields (`version`, `is_ready`), this automatically creates getter and setter properties for these fields in the Python class. So, from Python, you can do `status.version = "new"` and `print(status.version)`.
+    *   `internal_code: i32`: This field is *not* exposed with `#[pyo3(get, set)]`, so it won't be directly accessible as a property from Python. It's internal to the Rust struct.
+    *   **`#[pymethods]`**: This block contains methods associated with the `EngineStatus` struct that will be exposed to Python.
+        *   `#[new] fn new(...)`: This special method defines the constructor that Python will use when you write `EngineStatus("v1", True)` in Python.
+        *   `get_status_summary(&self)`: A regular method that Python instances can call. It can access internal fields like `self.internal_code`.
+        *   `set_internal_code_plus_one(&mut self)`: A method that modifies the Rust struct's state.
+    *   **`get_current_engine_status()`**: A new `#[pyfunction]` that creates and returns an instance of `EngineStatus`. PyO3 handles converting this Rust struct instance into a Python object of the `EngineStatus` class.
+    *   **`inspect_engine_status_from_python(status: &EngineStatus)`**: This function demonstrates receiving an instance of our `EngineStatus` class *from* Python. PyO3 converts the Python object back into a reference to the Rust `EngineStatus` struct.
+    *   **`m.add_class::<EngineStatus>()?`**: This line in the `#[pymodule]` function is crucial. It registers the `EngineStatus` struct (now a `PyClass`) with the Python module, making it available as a class in Python.
+
+    **OOP Analogy:** `#[pyclass]` effectively turns our Rust `struct EngineStatus` into a blueprint for a Python class. `#[pymethods]` defines the methods of this class. `#[new]` is the constructor. `#[pyo3(get, set)]` provides property-like access to fields, which is very Pythonic and similar to how attributes on objects work in OOP.
+
+2.  **Rebuild with Maturin:**
+    As always, after changing Rust code for PyO3:
+    *   Ensure your Python virtual environment is active.
+    *   In `GameEng/rust_core/`, run: `maturin develop --release` (or `maturin develop`).
+
+3.  **Use the Rust Class from Python:**
+    Update `GameEng/python_scripts/main_controller.py`:
+
+    ```python
+    # GameEng/python_scripts/main_controller.py
+    import dmtk_engine_rust
+
+    def main():
+        print("Python main_controller.py initialized.")
+
+        try:
+            # --- Previous calls (optional for brevity now) ---
+            # version = dmtk_engine_rust.get_engine_version()
+            # print(f"Engine Version: {version}")
+            # response = dmtk_engine_rust.process_data_from_python("PyUser", 10, True)
+            # print(f"Process Data Response: {response}")
+            # print("-" * 30)
+
+            # --- Test EngineStatus class from Rust ---
+            print("\nTesting EngineStatus class exposed from Rust:")
+
+            # 1. Create an instance of EngineStatus using the Rust constructor
+            print("\n1. Creating EngineStatus instance in Python (via Rust constructor)...")
+            status1 = dmtk_engine_rust.EngineStatus("v0.0.2-py", True)
+            print(f"[Python] Created status1: Version='{status1.version}', Ready='{status1.is_ready}'")
+            # status1.internal_code is not accessible directly here as it's not exposed via #[pyo3(get)]
+
+            # Call a method on the instance
+            summary1 = status1.get_status_summary()
+            print(f"[Python] status1.get_status_summary(): {summary1}")
+
+            # Modify using a method
+            status1.set_internal_code_plus_one() # Modifies internal_code in Rust
+            summary1_after_modify = status1.get_status_summary()
+            print(f"[Python] status1 summary after set_internal_code_plus_one(): {summary1_after_modify}")
+
+
+            # 2. Get an EngineStatus instance created in Rust
+            print("\n2. Getting EngineStatus instance created in Rust...")
+            status2 = dmtk_engine_rust.get_current_engine_status()
+            print(f"[Python] Received status2: Version='{status2.version}', Ready='{status2.is_ready}'")
+            summary2 = status2.get_status_summary()
+            print(f"[Python] status2.get_status_summary(): {summary2}")
+
+            # Modify its properties (if setters are exposed)
+            print("[Python] Modifying status2.is_ready and status2.version from Python...")
+            status2.is_ready = True
+            status2.version = "v0.1.0-beta-py"
+            summary2_modified = status2.get_status_summary() # Rust method sees the changes
+            print(f"[Python] status2 summary after Python modification: {summary2_modified}")
+
+            # 3. Pass a Python-created EngineStatus instance to Rust
+            print("\n3. Passing a Python-created EngineStatus (status1) to Rust function...")
+            dmtk_engine_rust.inspect_engine_status_from_python(status1)
+            print("[Python] inspect_engine_status_from_python call complete.")
+
+
+        except ImportError:
+            print("Error: Could not import the 'dmtk_engine_rust' module.")
+            print("Make sure you have built it with `maturin develop` in the rust_core directory.")
+        except Exception as e:
+            print(f"An error occurred: {e}")
+
+    if __name__ == "__main__":
+        main()
+    ```
+
+4.  **Run the Python Script:**
+    Ensure your venv is active. In `GameEng/`, run:
+    ```bash
+    python python_scripts/main_controller.py
+    ```
+    You should see output demonstrating:
+    *   Python creating an `EngineStatus` object (which calls the `#[new]` constructor in Rust).
+    *   Python accessing properties (`.version`, `.is_ready`) of the Rust-backed object.
+    *   Python calling methods (`.get_status_summary()`, `.set_internal_code_plus_one()`) on the object.
+    *   Python receiving an `EngineStatus` object fully created in Rust.
+    *   Python modifying properties of a Rust-created object, and those changes being reflected when a Rust method is called on it.
+    *   Python passing one of its `EngineStatus` instances to a Rust function that expects it.
+
+    Example output snippet:
+    ```
+    Testing EngineStatus class exposed from Rust:
+
+    1. Creating EngineStatus instance in Python (via Rust constructor)...
+    [Rust] EngineStatus constructor called from Python.
+    [Python] Created status1: Version='v0.0.2-py', Ready='True'
+    [Python] status1.get_status_summary(): EngineStatus: Version 'v0.0.2-py', Ready: true, Internal Code: 42
+    [Rust] internal_code incremented to: 43
+    [Python] status1 summary after set_internal_code_plus_one(): EngineStatus: Version 'v0.0.2-py', Ready: true, Internal Code: 43
+
+    2. Getting EngineStatus instance created in Rust...
+    [Rust] get_current_engine_status called.
+    [Python] Received status2: Version='0.1.0-alpha', Ready='False'
+    [Python] status2.get_status_summary(): EngineStatus: Version '0.1.0-alpha', Ready: false, Internal Code: 101
+    [Python] Modifying status2.is_ready and status2.version from Python...
+    [Python] status2 summary after Python modification: EngineStatus: Version 'v0.1.0-beta-py', Ready: true, Internal Code: 101
+
+    3. Passing a Python-created EngineStatus (status1) to Rust function...
+    [Rust] Received EngineStatus from Python:
+    [Rust]   Version: v0.0.2-py
+    [Rust]   Is Ready: true
+    [Rust]   Full Debug: EngineStatus { version: "v0.0.2-py", is_ready: true, internal_code: 43 }
+    [Python] inspect_engine_status_from_python call complete.
+    ```
+
+**Checkpoint 2.4 Summary:**
+Fantastic! We've successfully exposed a Rust struct (`EngineStatus`) as a Python class. Python code can now create instances of this class, access its properties (those exposed with `#[pyo3(get, set)]`), call its methods, receive instances created by Rust, and even pass its own instances back to Rust functions. This provides a very natural and powerful way to structure the interaction between the two languages, truly embodying the hybrid approach.
+
+**Phase 2 Complete!** We have a solid bridge between Python and Rust, allowing function calls and data exchange, including custom structured data.
+
+**Next:** We'll summarize what we've built and discuss the "Core Engine Ready" state and potential next steps for the student.
+
+## Core Engine Ready - Next Steps
+
+Congratulations! By completing Phase 1 and Phase 2, you've successfully built the foundational core of a hybrid Rust/Python game engine. Let's take a moment to appreciate what you've accomplished:
+
+**What You've Built:**
+
+1.  **A Rust Rendering Core (`render_core`):**
+    *   Can create an operating system window.
+    *   Initializes a modern graphics backend (`wgpu`).
+    *   Defines custom vertex structures.
+    *   Uses WGSL shaders (vertex and fragment) to control the GPU.
+    *   Implements a render pipeline to draw custom 2D geometry (a colored triangle).
+    *   Is organized into a reusable Rust module.
+
+2.  **Python-Rust Integration:**
+    *   Set up a Python project that can interface with the Rust core.
+    *   Successfully compiled the Rust core into a dynamic library that Python can import (using PyO3 and `maturin`).
+    *   Called simple Rust functions from Python.
+    *   Passed basic data types (strings, integers, booleans) between Python and Rust.
+    *   Exposed Rust structs as Python classes (`EngineStatus`), allowing Python to:
+        *   Instantiate these Rust-backed objects.
+        *   Get and set their (exposed) properties.
+        *   Call their methods.
+        *   Receive instances created in Rust.
+        *   Pass instances back to Rust functions.
+
+This is a significant achievement. You now have a system where the high-performance, low-level rendering is handled by Rust, and the higher-level control and scripting can be managed by Python. This forms the "Core Engine" – a robust skeleton ready for expansion.
+
+**The Path Forward: Expanding Your Engine**
+
+The beauty of this foundation is its extensibility. Here are some exciting directions you (the student) can explore to build upon this core, drawing inspiration from the original DMTK v2 vision discussed in the transcript:
+
+*   **Advanced 2D Rendering:**
+    *   **Sprite Rendering:** Create a system to draw 2D images (sprites). This would involve loading textures in Rust, modifying shaders to sample textures, and managing sprite positions and transformations.
+    *   **Batch Rendering:** Optimize rendering by drawing many sprites or shapes in fewer draw calls.
+    *   **Basic Scene Graph:** Implement a simple scene graph in Rust or Python to manage 2D game objects, their positions, and rendering order.
+
+*   **Input Handling:**
+    *   Extend the Rust `render_core` event loop (or the Python control loop, once established) to process keyboard and mouse input via `winit`.
+    *   Pass these input events to Python for game logic.
+
+*   **Moving to 3D:**
+    *   **3D Vertex Data:** Update your `Vertex` struct to include 3D positions (`[f32; 3]`).
+    *   **Camera System:** Implement a camera (view and projection matrices) in Rust. Pass these matrices to your shaders as uniforms.
+    *   **3D Models:** Load simple 3D models (e.g., `.obj` files) and render them.
+    *   **Depth Buffer:** Enable and use a depth buffer in `wgpu` for correct 3D occlusion.
+
+*   **Terrain Core (Rust):**
+    *   Adapt or port terrain generation algorithms (like those mentioned from C# in the transcript, e.g., using noise functions like Perlin or Simplex) into a new Rust module (`terrain_core`).
+    *   Generate heightmap data and create 3D meshes from it.
+    *   Render this terrain mesh using your `render_core`.
+    *   Explore chunking systems for large terrains.
+
+*   **Physics Core (Rust):**
+    *   Integrate a Rust physics library like `rapier` or `parry`.
+    *   Create a `physics_core` module.
+    *   Define simple physics bodies (e.g., cubes, spheres) and synchronize their state with rendered objects.
+    *   Expose physics interactions to Python (e.g., apply force, get position).
+
+*   **Python-Controlled Game Loop:**
+    *   This is a key architectural step. Instead of Rust's `render_core::run()` blocking, you'll want Python to drive the main game loop.
+    *   Rust could provide functions like `renderer.initialize()`, `renderer.render_frame()`, `physics.step_simulation()`.
+    *   Python would then call these in its loop:
+        ```python
+        # Simplified Python game loop idea
+        # renderer = dmtk_engine_rust.Renderer() # Assuming Renderer is a PyClass
+        # physics_world = dmtk_engine_rust.PhysicsWorld()
+        # renderer.init_with_window_handle(...) # More complex setup needed here
+
+        # while True:
+        #     handle_input()
+        #     dt = calculate_delta_time()
+        #     game_logic_update(dt)
+        #     physics_world.step(dt)
+        #     renderer.render_frame(game_state_to_render)
+        #     # This requires careful design of how Python tells Rust what/how to render
+        ```
+    *   This often involves running the Rust renderer/event loop in a separate thread managed by Rust, with Python sending commands or updates. Or, it might involve Python handling the windowing and event loop (e.g., with PySide/PyQt) and passing a window handle to Rust for `wgpu` to draw on. This is an advanced topic but crucial for full Python control.
+
+*   **AI, Quests, UI (Python):**
+    *   With the core systems in Rust, Python can shine in implementing:
+        *   NPC behavior (`npc_ai.py`).
+        *   Quest logic (`quest_logic.py`).
+        *   Developer/DM interfaces (`devinterface.py`) using Python GUI libraries like Dear PyGui, PyQt, or Kivy.
+
+*   **Networking (Rust or Hybrid):**
+    *   For multiplayer, a `server_core` in Rust could handle high-performance networking using libraries like `tokio`.
+    *   Python could interface with this server for game logic messages.
+
+This tutorial has laid the critical first stones. The path to a more complete engine involves iteratively building out these modules, always keeping the Rust-Python communication bridge in mind. Each new "core" (terrain, physics, etc.) would likely be a new Rust module, exposed to Python via PyO3, similar to how `render_core` and `EngineStatus` were handled.
+
+The journey of game engine development is challenging but incredibly rewarding. Experiment, break things, consult documentation (`wgpu`, `winit`, `pyo3` have excellent resources), and most importantly, have fun building your vision!
+
+## Final Touches
+
+You've come a long way from an empty directory to a foundational game engine with a Rust core and Python scripting capabilities! This is a remarkable starting point.
+
+**A Note on Object-Oriented Programming (OOP):**
+
+Throughout this tutorial, we've touched upon concepts that resonate with Object-Oriented Programming, even though Rust is often described as a multi-paradigm language with strong support for data-oriented design and trait-based polymorphism rather than classical inheritance-based OOP.
+
+*   **Encapsulation:** We saw this when we created the `render_core` module and the `Renderer` struct (formerly `WgpuState`). This struct bundles related data (like the `Device`, `Queue`, `RenderPipeline`) and the logic to operate on that data (`render()`, `resize()`). This hides internal complexity from the outside world, which only needs to call `render_core::run()` or interact with the `Renderer` object's public API.
+*   **Data Structures (Structs as Classes):** Rust `structs` (like `Vertex` and `EngineStatus`) serve a similar purpose to classes in OOP for holding data. When combined with `impl` blocks to define methods, they behave much like objects.
+*   **Behavior (Impl Blocks as Methods):** `impl` blocks allow us to define methods that operate on instances of our structs (e.g., `EngineStatus::get_status_summary()`). This is directly analogous to methods in a class.
+*   **Abstraction (PyO3 and Module Design):** The `render_core` module abstracts away the complexities of `wgpu`. Later, when Python interacts with `EngineStatus` via PyO3, it's working with an abstraction – it doesn't need to know the Rust-specific implementation details, only the Python class interface PyO3 provides. `#[pyclass]` is a powerful abstraction layer itself.
+*   **Composition over Inheritance:** While Rust doesn't have classical inheritance in the C++/Java sense, it heavily favors composition (structs containing other structs or data) and using traits for polymorphism (defining shared behavior). This is a modern and often more flexible approach to code reuse and design.
+
+Understanding these parallels can be helpful if you come from an OOP background. Rust provides the tools to build well-structured, maintainable, and highly performant systems, often achieving the same design goals as OOP through its own unique and powerful features.
+
+**Further Learning & Resources:**
+
+To continue your journey and expand your engine, here are some valuable resources:
+
+*   **Rust:**
+    *   The Official Rust Book ("The Rust Programming Language"): [https://doc.rust-lang.org/book/](https://doc.rust-lang.org/book/)
+    *   Rust by Example: [https://doc.rust-lang.org/rust-by-example/](https://doc.rust-lang.org/rust-by-example/)
+    *   Are We Game Yet? (For Rust game development ecosystem): [https://arewegameyet.com/](https://arewegameyet.com/)
+*   **WGPU:**
+    *   Official `wgpu` examples: [https://github.com/gfx-rs/wgpu/tree/master/wgpu/examples](https://github.com/gfx-rs/wgpu/tree/master/wgpu/examples)
+    *   Sotrh's Learn WGPU: [https://sotrh.github.io/learn-wgpu/](https://sotrh.github.io/learn-wgpu/) (Excellent tutorial series)
+    *   `wgpu` documentation: [https://docs.rs/wgpu/](https://docs.rs/wgpu/)
+*   **Winit:**
+    *   `winit` documentation and examples: [https://docs.rs/winit/](https://docs.rs/winit/)
+*   **PyO3:**
+    *   The PyO3 User Guide: [https://pyo3.rs/](https://pyo3.rs/) (Invaluable for Rust-Python bindings)
+*   **Game Development Concepts:**
+    *   Game Programming Patterns by Robert Nystrom: [https://gameprogrammingpatterns.com/](https://gameprogrammingpatterns.com/) (Free online book, great for design patterns)
+    *   LearnOpenGL: [https://learnopengl.com/](https://learnopengl.com/) (Though it uses C++ and OpenGL, the underlying graphics concepts are widely applicable)
+
+**Keep Experimenting:**
+
+The best way to learn is by doing. Try to implement one of the "Next Steps" outlined earlier. Start small, test frequently, and don't be afraid to look up solutions or ask questions in relevant communities (like the Rust Gamedev Discord or forums).
+
+You have the foundation. Now go build something amazing!


### PR DESCRIPTION
This commit introduces a comprehensive tutorial document, EngineTutorial.md, that guides users through building a foundational game engine using a hybrid Rust and Python approach.

The tutorial covers:
- Setting up the development environment for Rust and Python.
- Phase 1: Building the Rust core renderer using wgpu and winit, including window creation, graphics backend initialization, custom geometry rendering (triangles), and shader usage (WGSL). Code is refactored into a `render_core` module.
- Phase 2: Integrating Python with the Rust core using PyO3. This includes setting up PyO3, compiling Rust as a Python extension (using maturin), calling Rust functions from Python, passing basic data types, and exposing Rust structs as Python classes with methods and properties.

The tutorial emphasizes Object-Oriented Programming (OOP) analogies to help learners from various backgrounds and provides numerous code examples and explanations for each step.

It concludes with a summary of the achieved "Core Engine" state and suggestions for next steps and further learning resources.